### PR TITLE
Surface emissions

### DIFF
--- a/components/eam/src/chemistry/mozart/chemistry.F90
+++ b/components/eam/src/chemistry/mozart/chemistry.F90
@@ -1411,7 +1411,7 @@ end function chem_is_active
     use mo_chem_utls,        only : get_spc_ndx
     use cam_abortutils,      only: endrun
 
-    use mo_partmc_interface, only: partmc_mam_invoke
+    use mo_partmc_interface, only: partmc_mam_invoke, emissions_in_partmc
 
     implicit none
 
@@ -1695,6 +1695,12 @@ end function chem_is_active
             ncldwtr(:ncol,k) = state%q(:ncol,k,ixndrop)
     end do
 
+    call t_startf( 'partmc' )
+    ! FIXME: It will not compile if PartMC is off.
+    call emissions_in_partmc(cam_in%cflx)
+    call partmc_mam_invoke(state, dt)
+    call t_stopf( 'partmc' )
+
     call t_startf( 'chemdr' )
     call gas_phase_chemdr(lchnk, ncol, imozart, state%q, &
                           state%phis, state%zm, state%zi, calday, &
@@ -1710,11 +1716,7 @@ end function chem_is_active
 
     call t_stopf( 'chemdr' )
 
-    call t_startf( 'partmc' )
-    ! FIXME: It will not compile if PartMC is off.
-    !call invoke_partmc(ncol)
-    call partmc_mam_invoke(state, dt)
-    call t_stopf( 'partmc' )
+
 
 !-----------------------------------------------------------------------
 ! set flags for tracer tendencies (water and gas phase constituents)

--- a/components/eam/src/chemistry/mozart/chemistry.F90
+++ b/components/eam/src/chemistry/mozart/chemistry.F90
@@ -1697,8 +1697,7 @@ end function chem_is_active
 
     call t_startf( 'partmc' )
     ! FIXME: It will not compile if PartMC is off.
-    call emissions_in_partmc(cam_in%cflx)
-    call partmc_mam_invoke(state, dt)
+    call partmc_mam_invoke(state, cam_in%cflx, dt)
     call t_stopf( 'partmc' )
 
     call t_startf( 'chemdr' )

--- a/components/eam/src/chemistry/mozart/chemistry.F90
+++ b/components/eam/src/chemistry/mozart/chemistry.F90
@@ -1411,7 +1411,7 @@ end function chem_is_active
     use mo_chem_utls,        only : get_spc_ndx
     use cam_abortutils,      only: endrun
 
-    use mo_partmc_interface, only: partmc_mam_invoke, emissions_in_partmc
+    use mo_partmc_interface, only: partmc_mam_invoke
 
     implicit none
 

--- a/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
+++ b/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
@@ -40,6 +40,9 @@ module mo_partmc_interface
     integer :: dummy_index, dummy_i_repeat
     integer :: h2o_ndx,nmodes,nspec_max_modes
     real(kind=dp) :: n_part
+    ! mam information
+    character(len=256), allocatable :: mam_num_names(:)
+    character(len=256), allocatable :: mam_species_names(:,:)
 contains
 !-----------------------------------------------------------------------
   subroutine emissions_in_partmc(cflx )
@@ -86,6 +89,54 @@ contains
 
 end subroutine compute_nspec_max
 
+subroutine save_num_and_species_names(num_names, species_names)
+
+  use rad_constituents, only: rad_cnst_get_mode_num_idx, rad_cnst_get_mam_mmr_idx,rad_cnst_get_info
+  use mo_tracname, only : solsym
+  use mo_gas_phase_chemdr, only : map2chm
+
+  ! Arguments
+  character(len=*), intent(out) :: num_names(:)       ! Names of number fluxes per mode
+  character(len=*), intent(out) :: species_names(:,:) ! Names of species per mode
+
+  ! Local variables
+  integer :: n, ispec , nspec    ! Loop indices for modes and species
+  integer :: num_idx, spec_idx, idx_chm  ! Indices for number flux and species
+  character(len=256) :: species_name     ! Temporary variable for species name
+  character(len=256) :: num_name         ! Temporary variable for number flux name
+
+  ! Loop over modes to retrieve names
+  do n = 1, nmodes
+    ! Get the number flux index for the mode
+    call rad_cnst_get_mode_num_idx(n, num_idx)
+
+    ! Convert num_idx to chemistry index and retrieve the name
+    idx_chm = map2chm(num_idx)
+    if (idx_chm > 0) then
+      num_names(n) = solsym(idx_chm)
+    else
+      num_names(n) = "UNKNOWN"  ! Handle invalid index
+    end if
+
+    ! Loop over species in the mode to retrieve names
+    ! Get the number of species in the mode
+    call rad_cnst_get_info(0, n, nspec=nspec)
+    do ispec = 1, nspec
+      ! Get the species index for the mode and species
+      call rad_cnst_get_mam_mmr_idx(n, ispec, spec_idx)
+
+      ! Convert spec_idx to chemistry index and retrieve the name
+      idx_chm = map2chm(spec_idx)
+      if (idx_chm > 0) then
+        species_names(n, ispec) = solsym(idx_chm)
+      else
+        species_names(n, ispec) = "UNKNOWN"  ! Handle invalid index
+      end if
+    end do
+  end do
+
+end subroutine save_num_and_species_names
+
 subroutine compute_partmc_emission_inputs(surface_emmisions_mmr, ncol, mean_diameter, std_mam, num_fluxes, vmr_fraction)
 
   ! Compute emission inputs for PartMC based on modal aerosol properties.
@@ -94,6 +145,8 @@ subroutine compute_partmc_emission_inputs(surface_emmisions_mmr, ncol, mean_diam
   use chem_mods, only : adv_mass
   use physconst,        only: pi
   use mo_gas_phase_chemdr, only : map2chm
+  use constituents,     only: pcnst, sflxnam
+  use mo_tracname, only : solsym
   ! Arguments
   real(kind=dp), intent(in)  :: surface_emmisions_mmr(:,:)      ! Mass mixing ratio values (kg/kg-air)
   integer, intent(in)        :: ncol                 ! Number of columns
@@ -120,6 +173,7 @@ subroutine compute_partmc_emission_inputs(surface_emmisions_mmr, ncol, mean_diam
   list_idx = 0  ! Climate list by default
 
   ! Loop over modes to compute properties
+  mean_diameter(:,:)=0.0
   do n = 1, nmodes
     ! Initialize dry volume
     dryvol(:) = 0.0
@@ -135,6 +189,10 @@ subroutine compute_partmc_emission_inputs(surface_emmisions_mmr, ncol, mean_diam
 
     ! Get the number of species in the mode
     call rad_cnst_get_info(list_idx, n, nspec=nspec)
+    if (masterproc) then
+      idx_chm = map2chm(num_idx)
+      write(102,*) "sflxnam(", num_idx, "):", sflxnam(num_idx), "solsym : ", solsym(idx_chm)
+    end if
 
     ! Compute number fluxes
     do icol = 1, ncol
@@ -153,13 +211,19 @@ subroutine compute_partmc_emission_inputs(surface_emmisions_mmr, ncol, mean_diam
 
     ! Compute mean diameter
     do icol = 1, ncol
-      mean_diameter(icol, n) = (dryvol(icol) / (dumfac * num_fluxes(icol, n)))**third
+      if (num_fluxes(icol, n) /= 0) then
+        mean_diameter(icol, n) = (dryvol(icol) / (dumfac * num_fluxes(icol, n)))**third
+      end if
     end do
+    if (masterproc) then
+            write(102,*)  trim(adjustl(mam_num_names(n))) //": mean_diameter(", 1, ",", n, "):", mean_diameter(1, n)
+    end if
   end do
 
   ! Compute volume mixing ratio fractions
+  sum_mmr_per_mode(:,:) = 0.0
+  vmr_fraction(:, :, :)=0.0
   do n = 1, nmodes
-    sum_mmr_per_mode(:,:) = 0.0
     call rad_cnst_get_info(list_idx, n, nspec=nspec)
     do ispec = 1, nspec
       call rad_cnst_get_mam_mmr_idx(n, ispec, spec_idx)
@@ -170,6 +234,12 @@ subroutine compute_partmc_emission_inputs(surface_emmisions_mmr, ncol, mean_diam
             vmr_fraction(icol, n, ispec) = surface_emmisions_mmr(icol, spec_idx) / adv_mass(idx_chm)
             sum_mmr_per_mode(icol, n) = sum_mmr_per_mode(icol, n) + vmr_fraction(icol, n, ispec)
           end do
+          if (masterproc) then
+            write(102,*) "sflxnam(", spec_idx, "):", sflxnam(spec_idx), "solsym : ", solsym(idx_chm)
+            write(102,*) "surface_emmisions_mmr(", 1, ",", spec_idx, "):", surface_emmisions_mmr(1, spec_idx)
+            write(102,*) "adv_mass(", idx_chm, "):", adv_mass(idx_chm)
+            write(102,*) "sum_mmr_per_mode(", 1, ",", n, "):", sum_mmr_per_mode(1, n)
+          end if
         end if
       end if
     end do
@@ -179,9 +249,19 @@ subroutine compute_partmc_emission_inputs(surface_emmisions_mmr, ncol, mean_diam
   do n = 1, nmodes
     call rad_cnst_get_info(list_idx, n, nspec=nspec)
     do ispec = 1, nspec
-      do icol = 1, ncol
-        vmr_fraction(icol, n, ispec) = vmr_fraction(icol, n, ispec) / sum_mmr_per_mode(icol, n)
-      end do
+      idx_chm = map2chm(spec_idx)
+        if (idx_chm > 0) then
+          if (adv_mass(idx_chm) /= 0.0) then
+            do icol = 1, ncol
+              if (sum_mmr_per_mode(icol, n) /= 0.0) then
+                vmr_fraction(icol, n, ispec) = vmr_fraction(icol, n, ispec) / sum_mmr_per_mode(icol, n)
+              end if
+            end do
+          if (masterproc) then
+            write(102,*)  trim(adjustl(mam_species_names( n, ispec))) //" : vmr_fraction(", 1, ",", n, ",", ispec, "):", vmr_fraction(1, n, ispec)
+          end if
+          end if
+        end if
     end do
   end do
 
@@ -330,12 +410,13 @@ end subroutine compute_partmc_emission_inputs
    use rad_constituents, only: rad_cnst_get_info
 
    implicit none
-   integer :: i, n_species, n_aero_species, n_times, i_spec
+   integer :: i, n_species, n_aero_species, n_times, i_spec,i_mode, nspec
 
    character(len=100) :: file_name
    type(spec_file_t) :: file
    type(spec_file_t) :: sub_file
    type(aero_dist_t) :: aero_dist_init
+
 
    print*, 'in partmc initialization (new)'
 
@@ -383,6 +464,23 @@ end subroutine compute_partmc_emission_inputs
   ! Get the number of modes
   call rad_cnst_get_info(0, nmodes=nmodes)
   call compute_nspec_max(nspec_max_modes)
+  allocate(mam_num_names(nmodes))
+  allocate(mam_species_names(nmodes, nspec_max_modes))
+  call save_num_and_species_names(mam_num_names,mam_species_names)
+  if (masterproc) then
+    write(102,*) '-----------------------------------------'
+    write(102,*) 'save_num_and_species_names'
+    do i_mode = 1, nmodes
+      write(102, "(A)", advance="no") "Mode " // trim(adjustl(mam_num_names(i_mode))) // ": "
+      call rad_cnst_get_info(0, i_mode, nspec=nspec)
+      do i_spec = 1, nspec
+        write(102, "(A)", advance="no") trim(adjustl(mam_species_names(i_mode, i_spec))) // " "
+      end do
+      write(102,*)
+    end do
+    write(102,*) '-----------------------------------------'
+  endif
+
 
   end subroutine partmc_mam_inti
 

--- a/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
+++ b/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
@@ -143,6 +143,7 @@ subroutine compute_partmc_emission_inputs(cflx, ncol, geom_mean_diameter, std_ma
   real(kind=dp) :: dummwdens                        ! Dummy density factor
   real(kind=dp) :: dryvol(ncol)                        ! Dry volume for each column
   real(kind=dp) :: specdens
+  real(kind=dp) :: sum_vf_per_mode(ncol,nmodes)            ! Sum of mass mixing ratios per mode
   real(kind=dp), parameter :: third = 1.0 / 3.0  ! Constant for cube root calculation
 
   ! Initialize variables
@@ -198,6 +199,7 @@ subroutine compute_partmc_emission_inputs(cflx, ncol, geom_mean_diameter, std_ma
 
   ! Compute volume fractions
   volume_fractions(:, :, :)=0.0
+  sum_vf_per_mode(:,:) = 0.0
   do n = 1, nmodes
     call rad_cnst_get_info(list_idx, n, nspec=nspec)
     do ispec = 1, nspec
@@ -206,12 +208,34 @@ subroutine compute_partmc_emission_inputs(cflx, ncol, geom_mean_diameter, std_ma
       dummwdens = 1.0 / specdens
       do icol = 1, ncol
         volume_fractions(icol, n, ispec) =  cflx(icol, spec_idx) * dummwdens
+        sum_vf_per_mode(icol, n) = sum_vf_per_mode(icol, n) + volume_fractions(icol, n, ispec)
       end do
       if (masterproc) then
             write(102,*) "volume_fractions(", 1, n, ",", spec_idx, "):", volume_fractions(1,n, spec_idx)
       end if
     end do
   end do
+
+  ! Normalize volume mixing ratio fractions
+  do n = 1, nmodes
+    call rad_cnst_get_info(list_idx, n, nspec=nspec)
+    do ispec = 1, nspec
+      idx_chm = map2chm(spec_idx)
+        if (idx_chm > 0) then
+          if (adv_mass(idx_chm) /= 0.0) then
+            do icol = 1, ncol
+              if (sum_vf_per_mode(icol, n) /= 0.0) then
+                volume_fractions(icol, n, ispec) = volume_fractions(icol, n, ispec) / sum_vf_per_mode(icol, n)
+              end if
+            end do
+          if (masterproc) then
+            write(102,*)  trim(adjustl(mam_species_names( n, ispec))) //" : normalized volume_fractions(", 1, ",", n, ",", ispec, "):", volume_fractions(1, n, ispec)
+          end if
+          end if
+        end if
+    end do
+  end do
+
 end subroutine compute_partmc_emission_inputs
 
   subroutine spec_file_read_run_part_eam(run_part_opt, aero_data, &

--- a/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
+++ b/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
@@ -150,7 +150,7 @@ subroutine compute_partmc_emission_inputs(surface_emmisions_mmr, ncol, mean_diam
   ! Arguments
   real(kind=dp), intent(in)  :: surface_emmisions_mmr(:,:)      ! Mass mixing ratio values (kg/kg-air)
   integer, intent(in)        :: ncol                 ! Number of columns
-  real(kind=dp), intent(out) :: mean_diameter(:,:)   ! Mean diameter for each mode (m)
+  real(kind=dp), intent(out) :: mean_diameter(:,:)   ! Geometric dry mean diameter of the number distribution for each mode
   real(kind=dp), intent(out) :: std_mam(:)           ! Standard deviation for each mode
   real(kind=dp), intent(out) :: num_fluxes(:,:)      ! Number fluxes for each mode
   real(kind=dp), intent(out) :: vmr_fraction(:,:,:)  ! Volume mixing ratio fraction for each species

--- a/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
+++ b/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
@@ -38,9 +38,33 @@ module mo_partmc_interface
     logical :: do_init_equilibrate, aero_mode_type_exp_present
     character(len=PMC_MAX_FILENAME_LEN) :: restart_filename
     integer :: dummy_index, dummy_i_repeat
+    integer :: h2o_ndx
     real(kind=dp) :: n_part
 contains
 !-----------------------------------------------------------------------
+  subroutine emissions_in_partmc(cflx )
+  use dust_model, only: dust_names
+  use constituents,     only: pcnst, sflxnam
+  use mo_gas_phase_chemdr, only : map2chm
+  use camsrfexch,     only: cam_in_t
+  real(kind=dp),       intent(inout) :: cflx(pcols,pcnst)              ! constituent surface flux (kg/m^2/s)
+  integer :: m,n
+
+  if (masterproc) then
+         write(102,*) '-----------------------------------------'
+         write(102,*) 'PartMC emission ...'
+  ! units: num is 1 /m2/s and species  kg /m2/s
+  do m = 1,pcnst
+       n = map2chm(m)
+       if ( n /= h2o_ndx .and. n > 0 ) then
+          write(102,*)  sflxnam(m), " : ",  cflx(1,m)
+       endif
+  enddo
+  write(102,*) '-----------------------------------------'
+  endif
+
+  end subroutine emissions_in_partmc
+
   subroutine spec_file_read_run_part_eam(run_part_opt, aero_data, &
        env_state_init, &
        aero_dist_init, &
@@ -169,7 +193,7 @@ contains
     do i_mode = 1,n_emit_mode
        write(mode_name,'(a,i2.2)') 'emit_mode_', i_mode
        dummy = aero_data_source_by_name(aero_data, mode_name)
-       weight_class_name = mode_name 
+       weight_class_name = mode_name
        dummy = aero_data_weight_class_by_name(aero_data, &
             weight_class_name)
     end do
@@ -180,8 +204,11 @@ contains
    use mo_tracname, only : solsym
    use cam_history,  only : addfld
    use cam_history_support, only: add_hist_coord
+   use mo_chem_utls,        only : get_spc_ndx
+
    implicit none
    integer :: i, n_species, n_aero_species, n_times, i_spec
+
    character(len=100) :: file_name
    type(spec_file_t) :: file
    type(spec_file_t) :: sub_file
@@ -192,6 +219,8 @@ contains
   n_species=46 ! get from eam
   ! n_aero_species=7 ! get from eam
   n_times=1
+
+  h2o_ndx   = get_spc_ndx('H2O')
 
   call ensure_string_array_size(gas_data%name, n_species)
   call gas_state_set_size(gas_state, n_species)
@@ -253,7 +282,7 @@ contains
     n_species= gas_data_n_spec(gas_data)
     !FIXME: we must pass a delta time factor
     n_time = 30
-    run_part_opt%del_t = dt / n_time 
+    run_part_opt%del_t = dt / n_time
     run_part_opt%t_max = dt
     run_part_opt%i_repeat = 1
 
@@ -329,7 +358,7 @@ contains
            call aero_state_add_aero_dist_sample(aero_state, aero_data, &
                emissions, p, characteristic_factor, env_state%elapsed_time, &
                run_part_opt%allow_doubling, run_part_opt%allow_halving, n_emit)
-       
+
            ! Coagulation
            call mc_coag(run_part_opt%coag_kernel_type, env_state, &
                   aero_data, aero_state, run_part_opt%del_t, n_samp, n_coag)
@@ -348,7 +377,7 @@ contains
     end do ! kk
 
    ! Output to E3SM
-    do i = 1,aero_data_n_spec(aero_data) 
+    do i = 1,aero_data_n_spec(aero_data)
         call outfld( 'aero_particle_mass_'// trim(aero_data%name(i)), &
              aero_particle_mass_out(:ncol, :, :, i), ncol, lchnk )
     end do

--- a/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
+++ b/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
@@ -38,7 +38,7 @@ module mo_partmc_interface
     logical :: do_init_equilibrate, aero_mode_type_exp_present
     character(len=PMC_MAX_FILENAME_LEN) :: restart_filename
     integer :: dummy_index, dummy_i_repeat
-    integer :: h2o_ndx
+    integer :: h2o_ndx,nmodes,nspec_max_modes
     real(kind=dp) :: n_part
 contains
 !-----------------------------------------------------------------------
@@ -64,6 +64,128 @@ contains
   endif
 
   end subroutine emissions_in_partmc
+
+  subroutine compute_nspec_max(nspec_max)
+
+  use rad_constituents, only: rad_cnst_get_info
+
+  ! Arguments
+  integer, intent(out) :: nspec_max  ! Maximum number of species across all modes
+
+  ! Local variables
+  integer :: n           ! Loop index for modes
+  integer :: nspec       ! Number of species in the current mode
+
+  ! Initialize nspec_max
+  nspec_max = 0
+  ! Loop over modes to find the maximum number of species
+  do n = 1, nmodes
+    call rad_cnst_get_info(0, n, nspec=nspec)
+    nspec_max = max(nspec_max, nspec)
+  end do
+
+end subroutine compute_nspec_max
+
+subroutine compute_partmc_emission_inputs(surface_emmisions_mmr, ncol, mean_diameter, std_mam, num_fluxes, vmr_fraction)
+
+  ! Compute emission inputs for PartMC based on modal aerosol properties.
+  use rad_constituents, only: rad_cnst_get_info, rad_cnst_get_mode_props, rad_cnst_get_mode_num_idx, &
+                              rad_cnst_get_mam_mmr_idx, rad_cnst_get_aer_props
+  use chem_mods, only : adv_mass
+  use physconst,        only: pi
+  use mo_gas_phase_chemdr, only : map2chm
+  ! Arguments
+  real(kind=dp), intent(in)  :: surface_emmisions_mmr(:,:)      ! Mass mixing ratio values (kg/kg-air)
+  integer, intent(in)        :: ncol                 ! Number of columns
+  real(kind=dp), intent(out) :: mean_diameter(:,:)   ! Mean diameter for each mode (m)
+  real(kind=dp), intent(out) :: std_mam(:)           ! Standard deviation for each mode
+  real(kind=dp), intent(out) :: num_fluxes(:,:)      ! Number fluxes for each mode
+  real(kind=dp), intent(out) :: vmr_fraction(:,:,:)  ! Volume mixing ratio fraction for each species
+
+  ! Local variables
+  integer :: list_idx                          ! Index for climate or diagnostic list
+  integer :: nspec                             ! Number of species in a mode
+  integer :: n, ispec, icol                    ! Loop indices
+  integer :: num_idx, spec_idx, idx_chm        ! Indices for number flux, species, and chemistry mapping
+  real(kind=dp) :: sigmag                           ! Geometric standard deviation of mode
+  real(kind=dp) :: alnsg                            ! Logarithm of sigmag
+  real(kind=dp) :: dumfac                           ! Dummy factor for diameter calculation
+  real(kind=dp) :: dummwdens                        ! Dummy density factor
+  real(kind=dp) :: dryvol(ncol)                        ! Dry volume for each column
+  real(kind=dp) :: specdens
+  real(kind=dp) :: sum_mmr_per_mode(ncol,nmodes)            ! Sum of mass mixing ratios per mode
+  real(kind=dp), parameter :: third = 1.0 / 3.0  ! Constant for cube root calculation
+
+  ! Initialize variables
+  list_idx = 0  ! Climate list by default
+
+  ! Loop over modes to compute properties
+  do n = 1, nmodes
+    ! Initialize dry volume
+    dryvol(:) = 0.0
+
+    ! Get mode properties
+    call rad_cnst_get_mode_props(list_idx, n, sigmag=sigmag)
+    std_mam(n) = sigmag
+    alnsg = log(sigmag)
+    dumfac = exp(4.5 * alnsg**2) * pi / 6.0
+
+    ! Get number flux index
+    call rad_cnst_get_mode_num_idx(n, num_idx)
+
+    ! Get the number of species in the mode
+    call rad_cnst_get_info(list_idx, n, nspec=nspec)
+
+    ! Compute number fluxes
+    do icol = 1, ncol
+      num_fluxes(icol, n) = surface_emmisions_mmr(icol, num_idx)
+    end do
+
+    ! Compute dry volume
+    do ispec = 1, nspec
+      call rad_cnst_get_mam_mmr_idx(n, ispec, spec_idx)
+      call rad_cnst_get_aer_props(list_idx, n, ispec, density_aer=specdens)
+      dummwdens = 1.0 / specdens
+      do icol = 1, ncol
+        dryvol(icol) = dryvol(icol) + max(0.0, surface_emmisions_mmr(icol, spec_idx)) * dummwdens
+      end do
+    end do
+
+    ! Compute mean diameter
+    do icol = 1, ncol
+      mean_diameter(icol, n) = (dryvol(icol) / (dumfac * num_fluxes(icol, n)))**third
+    end do
+  end do
+
+  ! Compute volume mixing ratio fractions
+  do n = 1, nmodes
+    sum_mmr_per_mode(:,:) = 0.0
+    call rad_cnst_get_info(list_idx, n, nspec=nspec)
+    do ispec = 1, nspec
+      call rad_cnst_get_mam_mmr_idx(n, ispec, spec_idx)
+      idx_chm = map2chm(spec_idx)
+      if (idx_chm > 0) then
+        if (adv_mass(idx_chm) /= 0.0) then
+          do icol = 1, ncol
+            vmr_fraction(icol, n, ispec) = surface_emmisions_mmr(icol, spec_idx) / adv_mass(idx_chm)
+            sum_mmr_per_mode(icol, n) = sum_mmr_per_mode(icol, n) + vmr_fraction(icol, n, ispec)
+          end do
+        end if
+      end if
+    end do
+  end do
+
+  ! Normalize volume mixing ratio fractions
+  do n = 1, nmodes
+    call rad_cnst_get_info(list_idx, n, nspec=nspec)
+    do ispec = 1, nspec
+      do icol = 1, ncol
+        vmr_fraction(icol, n, ispec) = vmr_fraction(icol, n, ispec) / sum_mmr_per_mode(icol, n)
+      end do
+    end do
+  end do
+
+end subroutine compute_partmc_emission_inputs
 
   subroutine spec_file_read_run_part_eam(run_part_opt, aero_data, &
        env_state_init, &
@@ -205,6 +327,7 @@ contains
    use cam_history,  only : addfld
    use cam_history_support, only: add_hist_coord
    use mo_chem_utls,        only : get_spc_ndx
+   use rad_constituents, only: rad_cnst_get_info
 
    implicit none
    integer :: i, n_species, n_aero_species, n_times, i_spec
@@ -257,14 +380,20 @@ contains
   call addfld( 'aero_num_conc', (/'lev     ', 'npartmax' /), 'I', 'm^{-3}', &
        'number concentration for each particle' )
 
+  ! Get the number of modes
+  call rad_cnst_get_info(0, nmodes=nmodes)
+  call compute_nspec_max(nspec_max_modes)
+
   end subroutine partmc_mam_inti
 
-  subroutine partmc_mam_invoke(state, dt)
+  subroutine partmc_mam_invoke(state, cflx, dt)
     use physics_types,    only : physics_state
     use cam_history,       only : outfld
+    use constituents,     only: pcnst
 
     implicit none
     type(physics_state), intent(inout):: state
+    real(kind=dp),       intent(in) :: cflx(pcols,pcnst)              ! constituent surface flux (kg/m^2/s)
     real(kind=dp),            intent(in)    :: dt              ! time step
 
     integer :: i, n_species, icol, kk, lchnk, ncol, n_aero_species
@@ -272,8 +401,12 @@ contains
     real(kind=dp) ::  aero_component_len_out(pcols, pver,  n_part_max)
     real(kind=dp) ::  aero_num_conc_out(pcols, pver,  n_part_max)
     real(kind=dp) ::  number_conc_out(pcols, pver)
+    real(kind=dp) ::  mean_diameter(pcols, nmodes)
+    real(kind=dp) ::  sigma_mam(nmodes)
+    real(kind=dp) ::  num_fluxes(pcols, nmodes)
+    real(kind=dp) ::  vmr_fraction(pcols, nmodes, nspec_max_modes)
 
-    integer ::  n_samp, n_coag, i_time, n_time, n_emit
+    integer ::  n_samp, n_coag, i_time, n_time, n_emit,nmodes
     real(kind=dp) :: emission_rate_scale, p
     real(kind=dp) :: characteristic_factor
     type(aero_dist_t) :: emissions
@@ -302,10 +435,17 @@ contains
          write(102,*) '-----------------------------------------'
     endif
 
+    ! emissions
+
     ! FIXME: What time information does PartMC need here?
     env_state%start_time=0
     env_state%start_day=0
     env_state%elapsed_time=0d0
+
+    ! emission inputs
+    mean_diameter(:,:)=0
+    num_fluxes(:,:)=0
+    call compute_partmc_emission_inputs(cflx, ncol,mean_diameter, sigma_mam, num_fluxes, vmr_fraction)
 
     ! FIXME: Move inside the loop over cells.
     call partmc_interface_e3sm_emissions(state, emissions)

--- a/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
+++ b/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
@@ -209,7 +209,7 @@ subroutine compute_partmc_emission_inputs(surface_emmisions_mmr, ncol, mean_diam
       end do
     end do
 
-    ! Compute mean diameter
+    ! Compute geometric mean diameter
     do icol = 1, ncol
       if (num_fluxes(icol, n) /= 0) then
         mean_diameter(icol, n) = (dryvol(icol) / (dumfac * num_fluxes(icol, n)))**third

--- a/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
+++ b/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
@@ -151,7 +151,7 @@ subroutine compute_partmc_emission_inputs(surface_emmisions_mmr, ncol, mean_diam
   real(kind=dp), intent(in)  :: surface_emmisions_mmr(:,:)      ! Mass mixing ratio values (kg/kg-air)
   integer, intent(in)        :: ncol                 ! Number of columns
   real(kind=dp), intent(out) :: mean_diameter(:,:)   ! Geometric dry mean diameter of the number distribution for each mode
-  real(kind=dp), intent(out) :: std_mam(:)           ! Standard deviation for each mode
+  real(kind=dp), intent(out) :: std_mam(:)           ! Geometric standard deviation for each mode
   real(kind=dp), intent(out) :: num_fluxes(:,:)      ! Number fluxes for each mode
   real(kind=dp), intent(out) :: vmr_fraction(:,:,:)  ! Volume mixing ratio fraction for each species
 

--- a/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
+++ b/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
@@ -38,36 +38,13 @@ module mo_partmc_interface
     logical :: do_init_equilibrate, aero_mode_type_exp_present
     character(len=PMC_MAX_FILENAME_LEN) :: restart_filename
     integer :: dummy_index, dummy_i_repeat
-    integer :: h2o_ndx,nmodes,nspec_max_modes
+    integer :: nmodes,nspec_max_modes
     real(kind=dp) :: n_part
     ! mam information
     character(len=256), allocatable :: mam_num_names(:)
     character(len=256), allocatable :: mam_species_names(:,:)
 contains
 !-----------------------------------------------------------------------
-  subroutine emissions_in_partmc(cflx )
-  use dust_model, only: dust_names
-  use constituents,     only: pcnst, sflxnam
-  use mo_gas_phase_chemdr, only : map2chm
-  use camsrfexch,     only: cam_in_t
-  real(kind=dp),       intent(inout) :: cflx(pcols,pcnst)              ! constituent surface flux (kg/m^2/s)
-  integer :: m,n
-
-  if (masterproc) then
-         write(102,*) '-----------------------------------------'
-         write(102,*) 'PartMC emission ...'
-  ! units: num is 1 /m2/s and species  kg /m2/s
-  do m = 1,pcnst
-       n = map2chm(m)
-       if ( n /= h2o_ndx .and. n > 0 ) then
-          write(102,*)  sflxnam(m), " : ",  cflx(1,m)
-       endif
-  enddo
-  write(102,*) '-----------------------------------------'
-  endif
-
-  end subroutine emissions_in_partmc
-
   subroutine compute_nspec_max(nspec_max)
 
   use rad_constituents, only: rad_cnst_get_info
@@ -137,7 +114,7 @@ subroutine save_num_and_species_names(num_names, species_names)
 
 end subroutine save_num_and_species_names
 
-subroutine compute_partmc_emission_inputs(surface_emmisions_mmr, ncol, mean_diameter, std_mam, num_fluxes, vmr_fraction)
+subroutine compute_partmc_emission_inputs(cflx, ncol, geom_mean_diameter, std_mam, num_fluxes, volume_fractions)
 
   ! Compute emission inputs for PartMC based on modal aerosol properties.
   use rad_constituents, only: rad_cnst_get_info, rad_cnst_get_mode_props, rad_cnst_get_mode_num_idx, &
@@ -148,12 +125,12 @@ subroutine compute_partmc_emission_inputs(surface_emmisions_mmr, ncol, mean_diam
   use constituents,     only: pcnst, sflxnam
   use mo_tracname, only : solsym
   ! Arguments
-  real(kind=dp), intent(in)  :: surface_emmisions_mmr(:,:)      ! Mass mixing ratio values (kg/kg-air)
+  real(kind=dp), intent(in)  :: cflx(:,:)      ! constituent surface flux (kg/m^2/s for gas/aero species) or ( #/m^2/s) for num
   integer, intent(in)        :: ncol                 ! Number of columns
-  real(kind=dp), intent(out) :: mean_diameter(:,:)   ! Geometric dry mean diameter of the number distribution for each mode
+  real(kind=dp), intent(out) :: geom_mean_diameter(:,:)   ! Geometric dry mean diameter of the number distribution for each mode
   real(kind=dp), intent(out) :: std_mam(:)           ! Geometric standard deviation for each mode
-  real(kind=dp), intent(out) :: num_fluxes(:,:)      ! Number fluxes for each mode
-  real(kind=dp), intent(out) :: vmr_fraction(:,:,:)  ! Volume mixing ratio fraction for each species
+  real(kind=dp), intent(out) :: num_fluxes(:,:)      ! Number fluxes for each mode ( # / m^2 / s)
+  real(kind=dp), intent(out) :: volume_fractions(:,:,:)  ! Volume fractions for each species
 
   ! Local variables
   integer :: list_idx                          ! Index for climate or diagnostic list
@@ -166,14 +143,13 @@ subroutine compute_partmc_emission_inputs(surface_emmisions_mmr, ncol, mean_diam
   real(kind=dp) :: dummwdens                        ! Dummy density factor
   real(kind=dp) :: dryvol(ncol)                        ! Dry volume for each column
   real(kind=dp) :: specdens
-  real(kind=dp) :: sum_mmr_per_mode(ncol,nmodes)            ! Sum of mass mixing ratios per mode
   real(kind=dp), parameter :: third = 1.0 / 3.0  ! Constant for cube root calculation
 
   ! Initialize variables
   list_idx = 0  ! Climate list by default
 
   ! Loop over modes to compute properties
-  mean_diameter(:,:)=0.0
+  geom_mean_diameter(:,:)=0.0
   do n = 1, nmodes
     ! Initialize dry volume
     dryvol(:) = 0.0
@@ -196,7 +172,7 @@ subroutine compute_partmc_emission_inputs(surface_emmisions_mmr, ncol, mean_diam
 
     ! Compute number fluxes
     do icol = 1, ncol
-      num_fluxes(icol, n) = surface_emmisions_mmr(icol, num_idx)
+      num_fluxes(icol, n) = cflx(icol, num_idx)
     end do
 
     ! Compute dry volume
@@ -205,66 +181,37 @@ subroutine compute_partmc_emission_inputs(surface_emmisions_mmr, ncol, mean_diam
       call rad_cnst_get_aer_props(list_idx, n, ispec, density_aer=specdens)
       dummwdens = 1.0 / specdens
       do icol = 1, ncol
-        dryvol(icol) = dryvol(icol) + max(0.0, surface_emmisions_mmr(icol, spec_idx)) * dummwdens
+        dryvol(icol) = dryvol(icol) + max(0.0, cflx(icol, spec_idx)) * dummwdens
       end do
     end do
 
     ! Compute geometric mean diameter
     do icol = 1, ncol
       if (num_fluxes(icol, n) /= 0) then
-        mean_diameter(icol, n) = (dryvol(icol) / (dumfac * num_fluxes(icol, n)))**third
+        geom_mean_diameter(icol, n) = (dryvol(icol) / (dumfac * num_fluxes(icol, n)))**third
       end if
     end do
     if (masterproc) then
-            write(102,*)  trim(adjustl(mam_num_names(n))) //": mean_diameter(", 1, ",", n, "):", mean_diameter(1, n)
+            write(102,*)  trim(adjustl(mam_num_names(n))) //": geom_mean_diameter(", 1, ",", n, "):", geom_mean_diameter(1, n)
     end if
   end do
 
-  ! Compute volume mixing ratio fractions
-  sum_mmr_per_mode(:,:) = 0.0
-  vmr_fraction(:, :, :)=0.0
+  ! Compute volume fractions
+  volume_fractions(:, :, :)=0.0
   do n = 1, nmodes
     call rad_cnst_get_info(list_idx, n, nspec=nspec)
     do ispec = 1, nspec
       call rad_cnst_get_mam_mmr_idx(n, ispec, spec_idx)
-      idx_chm = map2chm(spec_idx)
-      if (idx_chm > 0) then
-        if (adv_mass(idx_chm) /= 0.0) then
-          do icol = 1, ncol
-            vmr_fraction(icol, n, ispec) = surface_emmisions_mmr(icol, spec_idx) / adv_mass(idx_chm)
-            sum_mmr_per_mode(icol, n) = sum_mmr_per_mode(icol, n) + vmr_fraction(icol, n, ispec)
-          end do
-          if (masterproc) then
-            write(102,*) "sflxnam(", spec_idx, "):", sflxnam(spec_idx), "solsym : ", solsym(idx_chm)
-            write(102,*) "surface_emmisions_mmr(", 1, ",", spec_idx, "):", surface_emmisions_mmr(1, spec_idx)
-            write(102,*) "adv_mass(", idx_chm, "):", adv_mass(idx_chm)
-            write(102,*) "sum_mmr_per_mode(", 1, ",", n, "):", sum_mmr_per_mode(1, n)
-          end if
-        end if
+      call rad_cnst_get_aer_props(list_idx, n, ispec, density_aer=specdens)
+      dummwdens = 1.0 / specdens
+      do icol = 1, ncol
+        volume_fractions(icol, n, ispec) =  cflx(icol, spec_idx) * dummwdens
+      end do
+      if (masterproc) then
+            write(102,*) "volume_fractions(", 1, n, ",", spec_idx, "):", volume_fractions(1,n, spec_idx)
       end if
     end do
   end do
-
-  ! Normalize volume mixing ratio fractions
-  do n = 1, nmodes
-    call rad_cnst_get_info(list_idx, n, nspec=nspec)
-    do ispec = 1, nspec
-      idx_chm = map2chm(spec_idx)
-        if (idx_chm > 0) then
-          if (adv_mass(idx_chm) /= 0.0) then
-            do icol = 1, ncol
-              if (sum_mmr_per_mode(icol, n) /= 0.0) then
-                vmr_fraction(icol, n, ispec) = vmr_fraction(icol, n, ispec) / sum_mmr_per_mode(icol, n)
-              end if
-            end do
-          if (masterproc) then
-            write(102,*)  trim(adjustl(mam_species_names( n, ispec))) //" : vmr_fraction(", 1, ",", n, ",", ispec, "):", vmr_fraction(1, n, ispec)
-          end if
-          end if
-        end if
-    end do
-  end do
-
 end subroutine compute_partmc_emission_inputs
 
   subroutine spec_file_read_run_part_eam(run_part_opt, aero_data, &
@@ -423,9 +370,6 @@ end subroutine compute_partmc_emission_inputs
   n_species=46 ! get from eam
   ! n_aero_species=7 ! get from eam
   n_times=1
-
-  h2o_ndx   = get_spc_ndx('H2O')
-
   call ensure_string_array_size(gas_data%name, n_species)
   call gas_state_set_size(gas_state, n_species)
 
@@ -499,10 +443,10 @@ end subroutine compute_partmc_emission_inputs
     real(kind=dp) ::  aero_component_len_out(pcols, pver,  n_part_max)
     real(kind=dp) ::  aero_num_conc_out(pcols, pver,  n_part_max)
     real(kind=dp) ::  number_conc_out(pcols, pver)
-    real(kind=dp) ::  mean_diameter(pcols, nmodes)
+    real(kind=dp) ::  geom_mean_diameter(pcols, nmodes)
     real(kind=dp) ::  sigma_mam(nmodes)
     real(kind=dp) ::  num_fluxes(pcols, nmodes)
-    real(kind=dp) ::  vmr_fraction(pcols, nmodes, nspec_max_modes)
+    real(kind=dp) ::  volume_fractions(pcols, nmodes, nspec_max_modes)
 
     integer ::  n_samp, n_coag, i_time, n_time, n_emit,nmodes
     real(kind=dp) :: emission_rate_scale, p
@@ -541,9 +485,9 @@ end subroutine compute_partmc_emission_inputs
     env_state%elapsed_time=0d0
 
     ! emission inputs
-    mean_diameter(:,:)=0
+    geom_mean_diameter(:,:)=0
     num_fluxes(:,:)=0
-    call compute_partmc_emission_inputs(cflx, ncol,mean_diameter, sigma_mam, num_fluxes, vmr_fraction)
+    call compute_partmc_emission_inputs(cflx, ncol,geom_mean_diameter, sigma_mam, num_fluxes, volume_fractions)
 
     ! FIXME: Move inside the loop over cells.
     call partmc_interface_e3sm_emissions(state, emissions)


### PR DESCRIPTION
Implementing the routine `compute_partmc_emission_inputs` to compute emission inputs for PartMC based on E3SM variables.
This routine takes constituent surface flux as input and outputs the mean dry diameter per mode (`mean_diameter`), standard deviation per mode (`std_mam`), fluxes of number concentration per mode (`num_fluxes`), and volume mixing ratio fraction per mode (`vmr_fraction`).

Note that MAM assumes a lognormal distribution per mode. `vmr_fraction` is an array of rank 3, with dimensions corresponding to the number of columns, modes, and the maximum number of species. Names of species per mode are stored in `mam_species_names`. This variable is set during initialization using the `save_num_and_species_names` routine, which is also implemented in this PR.

The number of species per mode can be obtained with the call:
`call rad_cnst_get_info(0, imode, nspec=nspec)`
where `imode` is the mode index and `nspec` is the number of species in mode `imode`. 

To build and run a case, use the following commands:

```
cd E3SM_REPO/cime/scripts
./create_test SMS_Ln5.ne30pg2_r05_IcoswISC30E3r5.F2010.mappy_gnu.eam-partmc-urban_plume
```

fixes #8 