### PR TITLE
PartMC interface: per-gridcell aerosol state and sector/natural-source emissions

### DIFF
--- a/components/eam/cime_config/testdefs/testmods_dirs/eam/partmc/urban_plume/user_nl_eam
+++ b/components/eam/cime_config/testdefs/testmods_dirs/eam/partmc/urban_plume/user_nl_eam
@@ -6,7 +6,7 @@ avgflag_pertape = 'A','A','A','A','I','I'
 nhtfrq = -24,-24,-6,-3,-1,-24
 mfilt  = 1,30,120,240,720,1
 
-fincl5 = 'aero_particle_mass_SO4','aero_particle_mass_BC','aero_num_conc','number_concentration'
+fincl5 = 'aero_num_conc','number_concentration', 'aero_particle_mass_BCPHO', 'aero_particle_mass_SSAM", "O3", 'aero_particle_mass_SULFATE', 'aero_particle_mass_OCPHO', 'aero_particle_mass_DUST4'
 
 ! -- chemUCI settings ------------------
 history_chemdyg_summary = .true.

--- a/components/eam/src/chemistry/modal_aero/aero_model.F90
+++ b/components/eam/src/chemistry/modal_aero/aero_model.F90
@@ -44,6 +44,9 @@ module aero_model
   public :: nimptblgrow_maxd
   public :: scavimptblnum
   public :: scavimptblvol
+  ! Exposed for the PartMC sector pathway to apply the same scale as
+  ! aero_model_emissions when computing sampled-mode sea salt fluxes.
+  public :: seasalt_emis_scale
 
  ! Misc private data 
 

--- a/components/eam/src/chemistry/modal_aero/dust_model.F90
+++ b/components/eam/src/chemistry/modal_aero/dust_model.F90
@@ -19,6 +19,10 @@ module dust_model
   public :: dust_init
   public :: dust_active
   public :: dust_dmt_grd
+  ! Exposed for the PartMC sector pathway so it can replicate the dust_emis
+  ! per-bin mass and number flux calculation without going through cflx.
+  public :: dust_emis_sclfctr   ! per-bin emission scale factor (parameter)
+  public :: dust_dmt_vwr        ! per-bin volume-weighted radius (set by dust_init)
 
   integer, parameter :: dust_nbin = 2
   integer, parameter :: dust_nnum = 2

--- a/components/eam/src/chemistry/modal_aero/dust_model.F90
+++ b/components/eam/src/chemistry/modal_aero/dust_model.F90
@@ -18,6 +18,7 @@ module dust_model
   public :: dust_readnl
   public :: dust_init
   public :: dust_active
+  public :: dust_dmt_grd
 
   integer, parameter :: dust_nbin = 2
   integer, parameter :: dust_nnum = 2

--- a/components/eam/src/chemistry/mozart/chemistry.F90
+++ b/components/eam/src/chemistry/mozart/chemistry.F90
@@ -1102,7 +1102,7 @@ end function chem_is_active
 
         ! FIXME: it will not compile if partmc is off.
     !call partmc_inti()
-    call partmc_mam_inti()
+    call partmc_mam_inti(phys_state, species_class)
 
   end subroutine chem_init
 

--- a/components/eam/src/chemistry/mozart/chemistry.F90
+++ b/components/eam/src/chemistry/mozart/chemistry.F90
@@ -1697,7 +1697,7 @@ end function chem_is_active
 
     call t_startf( 'partmc' )
     ! FIXME: It will not compile if PartMC is off.
-    call partmc_mam_invoke(state, cam_in%cflx, dt)
+    call partmc_mam_invoke(state, cam_in, cam_in%cflx, dt)
     call t_stopf( 'partmc' )
 
     call t_startf( 'chemdr' )

--- a/components/eam/src/chemistry/mozart/mo_srf_emissions.F90
+++ b/components/eam/src/chemistry/mozart/mo_srf_emissions.F90
@@ -29,7 +29,9 @@ module mo_srf_emissions
 
   private
 
-  public  :: srf_emissions_inti, set_srf_emissions, set_srf_emissions_time 
+  public  :: srf_emissions_inti, set_srf_emissions, set_srf_emissions_time
+  public  :: has_srf_emis_species, get_srf_emis_n_sectors, get_srf_emis_sector_name
+  public  :: get_srf_emis_sector_flux
 
   save
 
@@ -398,5 +400,99 @@ contains
     end do
 
   end subroutine set_srf_emissions
+
+  !---------------------------------------------------------------------
+  ! Sector-resolved accessors for downstream consumers (e.g. PartMC) that
+  ! need the per-sector breakdown rather than the species-summed flux.
+  !---------------------------------------------------------------------
+
+  logical function has_srf_emis_species( species_name )
+    character(len=*), intent(in) :: species_name
+    integer :: m
+
+    has_srf_emis_species = .false.
+    do m = 1,n_emis_species
+       if ( trim(emissions(m)%species) == trim(species_name) ) then
+          has_srf_emis_species = .true.
+          return
+       end if
+    end do
+  end function has_srf_emis_species
+
+  integer function get_srf_emis_n_sectors( species_name )
+    character(len=*), intent(in) :: species_name
+    integer :: m
+
+    get_srf_emis_n_sectors = 0
+    do m = 1,n_emis_species
+       if ( trim(emissions(m)%species) == trim(species_name) ) then
+          get_srf_emis_n_sectors = emissions(m)%nsectors
+          return
+       end if
+    end do
+  end function get_srf_emis_n_sectors
+
+  subroutine get_srf_emis_sector_name( species_name, isec, sector_name )
+    character(len=*), intent(in)  :: species_name
+    integer,          intent(in)  :: isec
+    character(len=*), intent(out) :: sector_name
+
+    integer :: m
+
+    sector_name = ''
+    do m = 1,n_emis_species
+       if ( trim(emissions(m)%species) == trim(species_name) ) then
+          if ( isec >= 1 .and. isec <= emissions(m)%nsectors ) then
+             sector_name = trim(emissions(m)%sectors(isec))
+          end if
+          return
+       end if
+    end do
+  end subroutine get_srf_emis_sector_name
+
+  ! Returns flux(:ncol) in kg/m^2/s for one sector of one species. Applies
+  ! the same unit conversion path as set_srf_emissions. Flux is zero if
+  ! the species or sector is not present.
+  subroutine get_srf_emis_sector_flux( species_name, sector_name, lchnk, ncol, flux )
+    use string_utils, only : to_lower, GLC
+
+    character(len=*), intent(in)  :: species_name
+    character(len=*), intent(in)  :: sector_name
+    integer,          intent(in)  :: lchnk
+    integer,          intent(in)  :: ncol
+    real(r8),         intent(out) :: flux(:)
+
+    integer :: m, isec, found_isec
+    real(r8) :: mfactor
+    character(len=12) :: units
+    character(len=12), parameter :: mks_units(4) = (/ "kg/m2/s     ", &
+                                                      "kg/m2/sec   ", &
+                                                      "kg/m^2/s    ", &
+                                                      "kg/m^2/sec  " /)
+
+    flux(:ncol) = 0._r8
+
+    do m = 1,n_emis_species
+       if ( trim(emissions(m)%species) /= trim(species_name) ) cycle
+
+       found_isec = 0
+       do isec = 1,emissions(m)%nsectors
+          if ( trim(emissions(m)%sectors(isec)) == trim(sector_name) ) then
+             found_isec = isec
+             exit
+          end if
+       end do
+       if ( found_isec == 0 ) return
+
+       flux(:ncol) = emissions(m)%fields(found_isec)%data(:ncol,1,lchnk)
+
+       units = to_lower(trim(emissions(m)%fields(1)%units(:GLC(emissions(m)%fields(1)%units))))
+       if ( .not. any( mks_units(:) == units ) ) then
+          mfactor = amufac * emissions(m)%mw
+          flux(:ncol) = flux(:ncol) * mfactor
+       end if
+       return
+    end do
+  end subroutine get_srf_emis_sector_flux
 
 end module mo_srf_emissions

--- a/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
+++ b/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
@@ -539,9 +539,11 @@ end subroutine compute_partmc_emission_inputs
           gas_state%mix_rat(i) = state%q(icol,kk,i) * 1d9
         end do ! species
 
-        if (masterproc) then
-           write(102,*) state%q(icol,kk,:)
-        end if
+        ! Debugging
+        !if (masterproc) then
+        !   write(102,*) state%q(icol,kk,:)
+        !end if
+
         ! FIXME: Think about how to best do this scenario/env_state.
         ! scenario%temp(:)  = state%t(icol,kk)
         ! scenario%pressure = state%pmid(icol,kk)
@@ -580,10 +582,10 @@ end subroutine compute_partmc_emission_inputs
            geom_mean_diameter(icol,:), sigma_mam, num_fluxes(icol,:), volume_fractions(icol, : , :))
         if (masterproc) then
            if (icol == 1) then
-           write(102,*) '-----------------------------------------'
-           write(102,*) 'grid cell | temperature | pressure | box height | altitude'
-           write(102,*) kk, env_state%temp, env_state%pressure,env_state%height,  env_state%altitude
-           write(102,*) '-----------------------------------------'
+              write(102,*) '-----------------------------------------'
+              write(102,*) 'grid cell | temperature | pressure | box height | altitude'
+              write(102,*) kk, env_state%temp, env_state%pressure,env_state%height,  env_state%altitude
+              write(102,*) '-----------------------------------------'
            end if
            if (kk == pver) then
               write(102,*) '-----------------------------------------'

--- a/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
+++ b/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
@@ -22,20 +22,55 @@ module mo_partmc_interface
     type(gas_data_t) :: gas_data
     type(gas_state_t) :: gas_state
     type(aero_data_t) :: aero_data
+
+    ! Array of aero_state for each chunk. (columns, levels)
     type aero_state_array_t
        type(aero_state_t), allocatable, dimension(:,:) :: aero_state
     end type aero_state_array_t
+    ! Array of aero_state_arrays. (chunks)
     type(aero_state_array_t), allocatable, dimension(:) :: aero_state_array
+
     type(scenario_t) :: scenario
     type(env_state_t) :: env_state
     type(env_state_t) :: env_state_init
     type(run_part_opt_t) :: run_part_opt
     integer :: i_repeat, i_group
     integer :: rand_init
+    ! Maximum number of computational particles. Used for output.
     integer, parameter, public :: n_part_max = 100
+    ! Maximum number of aerosol species. Used for output.
     integer, parameter, public :: n_aero_sp_max = 25
-    ! FIXME: Temporary set to fixed value 
-    integer, parameter, public :: n_emit_mode = 5 
+
+    ! Toggle between two emission pathways:
+    !   .false. — original cflx pathway (5 generic emit modes per MAM mode)
+    !   .true.  — sector-resolved pathway (one PartMC mode per (MAM mode, CMIP6 sector))
+    logical, parameter, public :: use_sector_emissions = .true.
+    ! Number of active PartMC emission modes. For the cflx pathway this stays 5;
+    ! for the sector pathway it is overwritten at init from the discovered
+    ! catalog (typically 14 for MAM4 + CMIP6 anthropogenic inventory).
+    integer, public :: n_emit_mode = 5
+    ! Canonical anthropogenic sector list (CMIP6 / AeroCom). The sector
+    ! catalog only registers a (MAM-group, sector) pair if the inventory
+    ! actually carries that variable.
+    integer, parameter :: n_canon_sectors = 8
+    character(len=8), parameter :: canon_sectors(n_canon_sectors) = &
+         (/ 'AGR     ', 'ENE     ', 'IND     ', 'RCO     ', &
+            'SHP     ', 'SLV     ', 'TRA     ', 'WST     ' /)
+    ! Per-mode catalog populated when use_sector_emissions = .true.
+    type sector_mode_t
+       character(len=32) :: name             ! e.g. emit_BCPOM_AGR
+       character(len=8) :: sector           ! canonical sector
+       integer :: parent_mam_mode  ! 1, 2, or 4
+       real(kind=dp) :: sigma_g          ! geometric std dev
+       integer :: n_mass           ! Number of species in the mass flux.
+       character(len=16), allocatable :: mass_species(:)  ! e.g. bc_a4, pom_a4
+       character(len=32), allocatable :: mass_sec_var(:)  ! sector var in that file
+       integer, allocatable :: mass_pmc_idx(:)  ! PartMC aero_data species index
+       integer :: n_num            ! Number of species in the number flux.
+       character(len=16), allocatable :: num_species(:)   ! num_aN
+       character(len=32), allocatable :: num_sec_var(:)   ! sector var in num file
+    end type sector_mode_t
+    type(sector_mode_t), allocatable :: sector_modes(:)
     character, allocatable :: buffer(:)
     integer :: buffer_size, max_buffer_size
     integer :: position
@@ -304,7 +339,11 @@ end subroutine compute_partmc_emission_inputs
     run_part_opt%parallel_coag_type = PARALLEL_COAG_TYPE_LOCAL
 
     do i_mode = 1,n_emit_mode
-       write(mode_name,'(a,i2.2)') 'emit_mode_', i_mode
+       if (use_sector_emissions) then
+          mode_name = sector_modes(i_mode)%name
+       else
+          write(mode_name,'(a,i2.2)') 'emit_mode_', i_mode
+       end if
        dummy = aero_data_source_by_name(aero_data, mode_name)
        weight_class_name = mode_name
        dummy = aero_data_weight_class_by_name(aero_data, &
@@ -390,6 +429,13 @@ end subroutine compute_partmc_emission_inputs
     call compute_nspec_max(nspec_max_modes)
     call aero_data_init(aero_data)
 
+    ! Build the (MAM-group, sector) catalog and override n_emit_mode if the
+    ! sector-resolved pathway is active. Must run before spec_file_read_run_part_eam
+    ! because that routine registers one aero_data source/weight-class per emit mode.
+    if (use_sector_emissions) then
+       call partmc_build_sector_catalog()
+    end if
+
     call spec_file_read_run_part_eam(run_part_opt, &
          env_state_init, n_part_ideal, rand_init)
 
@@ -456,6 +502,20 @@ end subroutine compute_partmc_emission_inputs
           write(102,*)
        end do
        write(102,*) '-----------------------------------------'
+
+       write(102,*) '-----------------------------------------'
+       write(102,*) 'aero_data sources (', size(aero_data%source_name), ')'
+       do i = 1, size(aero_data%source_name)
+          write(102,*) i, trim(aero_data%source_name(i))
+       end do
+       write(102,*) '-----------------------------------------'
+       write(102,*) 'aero_data weight classes (', size(aero_data%weight_class_name), ')'
+       do i = 1, size(aero_data%weight_class_name)
+          write(102,*) i, trim(aero_data%weight_class_name(i))
+       end do
+       write(102,*) '-----------------------------------------'
+       write(102,*) 'aero_state n_part_ideal = ', n_part_ideal
+       write(102,*) '-----------------------------------------'
     end if
 
   end subroutine partmc_mam_inti
@@ -476,10 +536,17 @@ end subroutine compute_partmc_emission_inputs
     real(kind=dp) ::  aero_particle_mass_out(pcols, pver,  n_part_max,n_aero_sp_max)
     real(kind=dp) ::  aero_num_conc_out(pcols, pver,  n_part_max)
     real(kind=dp) ::  number_conc_out(pcols, pver)
+    ! cflx-pathway arrays (indexed by MAM mode)
     real(kind=dp) ::  geom_mean_diameter(pcols, nmodes)
     real(kind=dp) ::  sigma_mam(nmodes)
     real(kind=dp) ::  num_fluxes(pcols, nmodes)
     real(kind=dp) ::  volume_fractions(pcols, nmodes, nspec_max_modes)
+    ! sector-pathway arrays (indexed by sector mode); allocatable so we only
+    ! pay the storage when the sector pathway is active
+    real(kind=dp), allocatable :: geom_mean_diameter_sec(:,:)
+    real(kind=dp), allocatable :: sigma_emode(:)
+    real(kind=dp), allocatable :: num_fluxes_sec(:,:)
+    real(kind=dp), allocatable :: vol_frac_sec(:,:,:)
 
     integer ::  n_samp, n_coag, i_time, n_time, n_emit
     integer :: i_mode
@@ -522,10 +589,19 @@ end subroutine compute_partmc_emission_inputs
     env_state%elapsed_time = 0d0
 
     ! Emission inputs from E3SM
-    geom_mean_diameter(:,:) = 0d0
-    num_fluxes(:,:) = 0d0
-    call compute_partmc_emission_inputs(cflx, ncol, geom_mean_diameter, &
-         sigma_mam, num_fluxes, volume_fractions)
+    if (use_sector_emissions) then
+       allocate(geom_mean_diameter_sec(pcols, n_emit_mode))
+       allocate(sigma_emode(n_emit_mode))
+       allocate(num_fluxes_sec(pcols, n_emit_mode))
+       allocate(vol_frac_sec(pcols, n_emit_mode, aero_data_n_spec(aero_data)))
+       call compute_partmc_emission_inputs_sector(lchnk, ncol, &
+            geom_mean_diameter_sec, sigma_emode, num_fluxes_sec, vol_frac_sec)
+    else
+       geom_mean_diameter(:,:) = 0d0
+       num_fluxes(:,:) = 0d0
+       call compute_partmc_emission_inputs(cflx, ncol, geom_mean_diameter, &
+            sigma_mam, num_fluxes, volume_fractions)
+    end if
 
     do kk = 1,pver
        do icol = 1,ncol
@@ -575,8 +651,14 @@ end subroutine compute_partmc_emission_inputs
           n_samp = 0
           n_emit = 0
           ! Set the PartMC data structure for aerosol emissions
-          call partmc_interface_e3sm_emissions(state, emissions, &
-               geom_mean_diameter(icol,:), sigma_mam, num_fluxes(icol,:), volume_fractions(icol,:,:))
+          if (use_sector_emissions) then
+             call partmc_interface_e3sm_emissions_sector(emissions, &
+                  geom_mean_diameter_sec(icol,:), sigma_emode, &
+                  num_fluxes_sec(icol,:), vol_frac_sec(icol,:,:))
+          else
+             call partmc_interface_e3sm_emissions(state, emissions, &
+                  geom_mean_diameter(icol,:), sigma_mam, num_fluxes(icol,:), volume_fractions(icol,:,:))
+          end if
 
           if (masterproc) then
              if (icol == 1) then
@@ -587,11 +669,18 @@ end subroutine compute_partmc_emission_inputs
              end if
              if (kk == pver) then
                 write(102,*) '-----------------------------------------'
-                write(102,*) 'i_mode | radius | log10sigma | number flux'
+                write(102,*) 'i_mode | name | radius | log10sigma | number flux'
                 do i_mode = 1,n_emit_mode
-                   write(102,*) i_mode, emissions%mode(i_mode)%char_radius, &
+                   write(102,*) i_mode, trim(emissions%mode(i_mode)%name), &
+                        emissions%mode(i_mode)%char_radius, &
                         emissions%mode(i_mode)%log10_std_dev_radius, &
                         emissions%mode(i_mode)%num_conc
+                   do i = 1,aero_data_n_spec(aero_data)
+                      if (emissions%mode(i_mode)%vol_frac(i) > 0.0d0) then
+                         write(102,*) '   vol_frac ', trim(aero_data%name(i)), &
+                              emissions%mode(i_mode)%vol_frac(i)
+                      end if
+                   end do
                 end do
                 write(102,*) '-----------------------------------------'
              end if
@@ -637,6 +726,10 @@ end subroutine compute_partmc_emission_inputs
     call outfld( 'number_concentration', number_conc_out(:ncol, :), ncol, lchnk )
     call outfld( 'aero_num_conc', aero_num_conc_out(:ncol, :, :), ncol, lchnk )
 
+    if (use_sector_emissions) then
+       deallocate(geom_mean_diameter_sec, sigma_emode, num_fluxes_sec, vol_frac_sec)
+    end if
+
   end subroutine partmc_mam_invoke
 
   ! Populates aero_state_array with the initial aerosol distribution for chunk
@@ -675,6 +768,7 @@ end subroutine compute_partmc_emission_inputs
        aero_dist_init%mode(i_mode)%sample_radius = [ real(kind=dp) :: ]
        aero_dist_init%mode(i_mode)%sample_num_conc = [ real(kind=dp) :: ]
     end do
+
     do kk = 1,pver
        do icol = 1,ncol
           do i_mode = 1,ntot_amode
@@ -740,6 +834,8 @@ end subroutine compute_partmc_emission_inputs
                run_part_opt%allow_halving)
        end do
     end do
+
+    ! Flag to indicate the initial condition has been set for this chunk.
     q_init_saved(lchnk) = .true.
 
   end subroutine partmc_init_aero_dist
@@ -765,7 +861,7 @@ end subroutine compute_partmc_emission_inputs
 
   n_part=aero_state_n_part(aero_state)
   n_sp_aero=aero_data_n_spec(aero_data)
-  if ( n_part> 0) then
+  if (n_part > 0) then
     do i_part = 1,n_part
      aero_particle_mass(i_part, :) &
          = aero_state%apa%particle(i_part)%vol * aero_data%density
@@ -974,7 +1070,7 @@ end subroutine compute_partmc_emission_inputs
        aero_data%num_ions(i_spec) = 0
     end do
 
-    ! Set the optical wavelength.
+    ! Set the optical wavelength (not used)
     aero_data%wavelengths = 550.0d0
 
     ! Set the index of water
@@ -982,6 +1078,7 @@ end subroutine compute_partmc_emission_inputs
     ! Set MOSAIC map (not used)
     call aero_data_set_mosaic_map(aero_data)
 
+    ! Set fractal properties
     call fractal_set_spherical(aero_data%fractal)
 
     ! Map MAM "species" to PartMC species
@@ -990,8 +1087,7 @@ end subroutine compute_partmc_emission_inputs
     do m = 1,n_modes
        call rad_cnst_get_info(list_idx, m, nspec=n_spec)
        do l = 1,n_spec
-          call rad_cnst_get_aer_props(list_idx, m, l, &
-               aername = aername)
+          call rad_cnst_get_aer_props(list_idx, m, l, aername = aername)
           ! Find the index
           mam_spec_to_partmc_spec(m,l) = aero_data_spec_by_name(aero_data, aername) 
       end do
@@ -1003,7 +1099,7 @@ end subroutine compute_partmc_emission_inputs
     ! Print results
     if (masterproc) then
        write(102,*) 'Contents of aero_data'
-       write(102,*) 'Name | Density | MW | kappa'
+       write(102,*) 'Name | Density | Molecular weight | kappa'
        do i_spec = 1,n_aero_spec
           write(102,*) trim(aero_data%name(i_spec)), aero_data%density(i_spec), &
              aero_data%molec_weight(i_spec), aero_data%kappa(i_spec)
@@ -1011,5 +1107,338 @@ end subroutine compute_partmc_emission_inputs
     end if
 
   end subroutine aero_data_init
+
+  !---------------------------------------------------------------------
+  ! Sector-resolved emissions handling
+  !---------------------------------------------------------------------
+
+  ! Resolves a MAM constituent name (e.g. 'bc_a4', 'so4_a1') to the
+  ! corresponding PartMC aero_data species index by walking MAM modes.
+  ! Returns 0 if the constituent is not found in any mode.
+  integer function pmc_idx_for_constituent(constituent_name)
+    use rad_constituents, only : rad_cnst_get_info, rad_cnst_get_mam_mmr_idx, &
+                                    rad_cnst_get_aer_props
+    use mo_tracname, only : solsym
+    use mo_gas_phase_chemdr, only : map2chm
+
+    ! MAM species name to resolve (e.g. 'bc_a4', 'so4_a1')
+    character(len=*), intent(in) :: constituent_name
+
+    integer :: m, l, nspec, spec_idx, idx_chm
+    character(len=20) :: aername
+
+    pmc_idx_for_constituent = 0
+    do m = 1,nmodes
+       call rad_cnst_get_info(list_idx, m, nspec=nspec)
+       do l = 1,nspec
+          call rad_cnst_get_mam_mmr_idx(m, l, spec_idx)
+          idx_chm = map2chm(spec_idx)
+          if (idx_chm > 0) then
+             if (trim(solsym(idx_chm)) == trim(constituent_name)) then
+                call rad_cnst_get_aer_props(list_idx, m, l, aername=aername)
+                pmc_idx_for_constituent = aero_data_spec_by_name(aero_data, aername)
+                return
+             end if
+          end if
+       end do
+    end do
+
+  end function pmc_idx_for_constituent
+
+  ! Returns .true. if the given srf-emis species carries the named sector
+  ! variable. Sector names match the raw NetCDF variable names exactly
+  ! (e.g. 'AGR' for so4_a1, 'num_a1_BC_AGR' for num_a4). Note the possibility of
+  ! a1/a4 issue in the inputs.
+  logical function species_has_sector(species_name, sector_name)
+    use mo_srf_emissions, only : has_srf_emis_species, &
+                                 get_srf_emis_n_sectors, &
+                                 get_srf_emis_sector_name
+
+    ! Species name.
+    character(len=*), intent(in) :: species_name
+    ! Sector name.
+    character(len=*), intent(in) :: sector_name
+
+    integer :: nsec, isec
+    character(len=32) :: sname
+
+    species_has_sector = .false.
+    if ( .not. has_srf_emis_species(species_name)) return
+    nsec = get_srf_emis_n_sectors(species_name)
+    do isec = 1,nsec
+       call get_srf_emis_sector_name(species_name, isec, sname)
+       if (trim(sname) == trim(sector_name) ) then
+          species_has_sector = .true.
+          return
+       end if
+    end do
+
+  end function species_has_sector
+
+  ! Walks the canonical CMIP6 anthropogenic sector list and builds one
+  ! sector_modes entry per (MAM-group, sector) pair that is actually present
+  ! in the inventory. Sets module-level n_emit_mode to the discovered count.
+  !
+  ! MAM-groups handled (MAM4 + CMIP6):
+  !   * BCPOM  (parent mode 4) — bc_a4 + pom_a4 + num_a4
+  !   * SO4a1  (parent mode 1) — so4_a1 + num_a1
+  !   * SO4a2  (parent mode 2) — so4_a2 + num_a2
+  !
+  ! The MAM split between so4_a1/so4_a2 (and the corresponding number)
+  ! is inherited as-is.
+  subroutine partmc_build_sector_catalog()
+    use modal_aero_data, only : sigmag_amode
+
+    integer :: i_sec, i_out, i_pass
+    character(len=8) :: sector
+    logical :: have_bcpom, have_so4a1, have_so4a2
+
+    ! Pass 1: Count the number of emission modes based on sectors.
+    ! Pass 2: Populate sector information.
+    do i_pass = 1,2
+       i_out = 0
+       do i_sec = 1,n_canon_sectors
+          sector = canon_sectors(i_sec)
+
+          have_bcpom = species_has_sector('bc_a4',  trim(sector)) .and. &
+                       species_has_sector('pom_a4', trim(sector))
+          have_so4a1 = species_has_sector('so4_a1', trim(sector))
+          have_so4a2 = species_has_sector('so4_a2', trim(sector))
+
+          ! Handle Hydrophobic BCPOM sectors in a4 (Accumulation) mode.
+          if (have_bcpom) then
+             i_out = i_out + 1
+             if (i_pass == 2) then
+                sector_modes(i_out)%name = 'emit_BCPOM_'//trim(sector)
+                sector_modes(i_out)%sector = sector
+                sector_modes(i_out)%parent_mam_mode = 4
+                sector_modes(i_out)%sigma_g = sigmag_amode(4)
+                sector_modes(i_out)%n_mass = 2
+                allocate(sector_modes(i_out)%mass_species(2))
+                allocate(sector_modes(i_out)%mass_sec_var(2))
+                allocate(sector_modes(i_out)%mass_pmc_idx(2))
+                sector_modes(i_out)%mass_species(1) = 'bc_a4'
+                sector_modes(i_out)%mass_sec_var(1) = trim(sector)
+                sector_modes(i_out)%mass_pmc_idx(1) = pmc_idx_for_constituent('bc_a4')
+                sector_modes(i_out)%mass_species(2) = 'pom_a4'
+                sector_modes(i_out)%mass_sec_var(2) = trim(sector)
+                sector_modes(i_out)%mass_pmc_idx(2) = pmc_idx_for_constituent('pom_a4')
+                sector_modes(i_out)%n_num = 2
+                allocate(sector_modes(i_out)%num_species(2))
+                allocate(sector_modes(i_out)%num_sec_var(2))
+                ! WARNING: num_a4 file uses 'num_a1_BC_*' / 'num_a1_POM_*' variable names
+                ! (CMIP6 inventory artifact — naming follows the chemistry, not
+                ! the destination MAM mode).
+                sector_modes(i_out)%num_species(1) = 'num_a4'
+                sector_modes(i_out)%num_sec_var(1) = 'num_a1_BC_'//trim(sector)
+                sector_modes(i_out)%num_species(2) = 'num_a4'
+                sector_modes(i_out)%num_sec_var(2) = 'num_a1_POM_'//trim(sector)
+             end if
+          end if
+
+          ! Handle SO4 mode a1 (Accumulation) sectors.
+          if (have_so4a1) then
+             i_out = i_out + 1
+             if (i_pass == 2) then
+                sector_modes(i_out)%name = 'emit_SO4a1_'//trim(sector)
+                sector_modes(i_out)%sector = sector
+                sector_modes(i_out)%parent_mam_mode = 1
+                sector_modes(i_out)%sigma_g = sigmag_amode(1)
+                sector_modes(i_out)%n_mass = 1
+                allocate(sector_modes(i_out)%mass_species(1))
+                allocate(sector_modes(i_out)%mass_sec_var(1))
+                allocate(sector_modes(i_out)%mass_pmc_idx(1))
+                sector_modes(i_out)%mass_species(1) = 'so4_a1'
+                sector_modes(i_out)%mass_sec_var(1) = trim(sector)
+                sector_modes(i_out)%mass_pmc_idx(1) = pmc_idx_for_constituent('so4_a1')
+                sector_modes(i_out)%n_num = 1
+                allocate(sector_modes(i_out)%num_species(1))
+                allocate(sector_modes(i_out)%num_sec_var(1))
+                sector_modes(i_out)%num_species(1) = 'num_a1'
+                sector_modes(i_out)%num_sec_var(1) = 'num_a1_SO4_'//trim(sector)
+             end if
+          end if
+
+          ! Handle SO4 mode a2 (Aitken) sectors.
+          if (have_so4a2) then
+             i_out = i_out + 1
+             if (i_pass == 2) then
+                sector_modes(i_out)%name = 'emit_SO4a2_'//trim(sector)
+                sector_modes(i_out)%sector = sector
+                sector_modes(i_out)%parent_mam_mode = 2
+                sector_modes(i_out)%sigma_g = sigmag_amode(2)
+                sector_modes(i_out)%n_mass = 1
+                allocate(sector_modes(i_out)%mass_species(1))
+                allocate(sector_modes(i_out)%mass_sec_var(1))
+                allocate(sector_modes(i_out)%mass_pmc_idx(1))
+                sector_modes(i_out)%mass_species(1) = 'so4_a2'
+                sector_modes(i_out)%mass_sec_var(1) = trim(sector)
+                sector_modes(i_out)%mass_pmc_idx(1) = pmc_idx_for_constituent('so4_a2')
+                sector_modes(i_out)%n_num = 1
+                allocate(sector_modes(i_out)%num_species(1))
+                allocate(sector_modes(i_out)%num_sec_var(1))
+                sector_modes(i_out)%num_species(1) = 'num_a2'
+                sector_modes(i_out)%num_sec_var(1) = 'num_a2_SO4_'//trim(sector)
+             end if
+          end if
+       end do
+
+       if (i_pass == 1) then
+          n_emit_mode = i_out
+          allocate(sector_modes(n_emit_mode))
+       end if
+    end do
+
+    if (masterproc) then
+       write(102,*) '-----------------------------------------'
+       write(102,*) 'PartMC sector emission catalog'
+       write(102,*) 'n_emit_mode = ', n_emit_mode
+       do i_out = 1,n_emit_mode
+          write(102,*) i_out, ' ', trim(sector_modes(i_out)%name), &
+               ' parent_mam=', sector_modes(i_out)%parent_mam_mode, &
+               ' sigma_g=', sector_modes(i_out)%sigma_g
+       end do
+       write(102,*) '-----------------------------------------'
+    end if
+
+  end subroutine partmc_build_sector_catalog
+
+  ! Sector-resolved versions of compute_partmc_emission_inputs.
+  ! Produces per-(column, sector_mode) inputs for PartMC. vol_frac is indexed
+  ! directly by PartMC aero_data species index (not the per-mode species index)
+  ! because each sector_mode lists its constituents.
+  subroutine compute_partmc_emission_inputs_sector(lchnk, ncol, &
+       geom_mean_diameter, sigma_emode, num_fluxes, vol_frac)
+    use mo_srf_emissions, only : get_srf_emis_sector_flux
+    use physconst, only : pi
+
+    ! Chunk index.
+    integer, intent(in)  :: lchnk
+    ! Number of columns in chunk.
+    integer, intent(in)  :: ncol
+    ! Geometric mean diameter of each sector mode.
+    real(kind=dp), intent(out) :: geom_mean_diameter(:,:) ! (pcols, n_emit_mode)
+    ! Geometric standard deviation of each sector mode.
+    real(kind=dp), intent(out) :: sigma_emode(:) ! (n_emit_mode)
+    ! Number flux of each sector mode.
+    real(kind=dp), intent(out) :: num_fluxes(:,:) ! (pcols, n_emit_mode)
+    ! Volume fraction of each PartMC species in each sector mode.
+    real(kind=dp), intent(out) :: vol_frac(:,:,:) ! (pcols, n_emit_mode, n_aero_spec)
+
+    integer  :: i_mode, j, icol, pmc_idx
+    real(kind=dp) :: alnsg, dumfac, specdens, dummwdens
+    real(kind=dp) :: tmp(pcols)
+    real(kind=dp) :: dryvol(pcols), sum_vf(pcols)
+
+    geom_mean_diameter(:,:) = 0.0d0
+    num_fluxes(:,:) = 0.0d0
+    vol_frac(:,:,:) = 0.0d0
+
+    do i_mode = 1,n_emit_mode
+       sigma_emode(i_mode) = sector_modes(i_mode)%sigma_g
+       alnsg  = log(sector_modes(i_mode)%sigma_g)
+       dumfac = exp(4.5d0 * alnsg**2) * pi / 6.0d0
+
+       ! Sum number flux across all num sources for this sector mode
+       do j = 1,sector_modes(i_mode)%n_num
+          call get_srf_emis_sector_flux( &
+               sector_modes(i_mode)%num_species(j), &
+               sector_modes(i_mode)%num_sec_var(j), &
+               lchnk, ncol, tmp)
+          do icol = 1, ncol
+             num_fluxes(icol, i_mode) = num_fluxes(icol, i_mode) + tmp(icol)
+          end do
+       end do
+
+       ! Accumulate dry volume flux per species; unnormalized vol_frac stored in place
+       dryvol(:) = 0.0d0
+       sum_vf(:) = 0.0d0
+       do j = 1,sector_modes(i_mode)%n_mass
+          pmc_idx = sector_modes(i_mode)%mass_pmc_idx(j)
+          if (pmc_idx <= 0) cycle
+          specdens  = aero_data%density(pmc_idx)
+          dummwdens = 1.0d0 / specdens
+          call get_srf_emis_sector_flux( &
+               sector_modes(i_mode)%mass_species(j), &
+               sector_modes(i_mode)%mass_sec_var(j), &
+               lchnk, ncol, tmp)
+          do icol = 1,ncol
+             vol_frac(icol, i_mode, pmc_idx) = max(0.0d0, tmp(icol)) * dummwdens
+             dryvol(icol) = dryvol(icol) + vol_frac(icol, i_mode, pmc_idx)
+             sum_vf(icol) = sum_vf(icol) + vol_frac(icol, i_mode, pmc_idx)
+          end do
+       end do
+
+       do icol = 1,ncol
+          if (num_fluxes(icol, i_mode) > 0.0d0) then
+             geom_mean_diameter(icol, i_mode) = &
+                  (dryvol(icol) / (dumfac * num_fluxes(icol, i_mode)))**third
+          end if
+       end do
+
+       ! Normalize vol_frac.
+       do j = 1,sector_modes(i_mode)%n_mass
+          pmc_idx = sector_modes(i_mode)%mass_pmc_idx(j)
+          if (pmc_idx <= 0) cycle
+          do icol = 1,ncol
+             if (sum_vf(icol) > 0.0d0) then
+                vol_frac(icol, i_mode, pmc_idx) = vol_frac(icol, i_mode, pmc_idx) / sum_vf(icol)
+             end if
+          end do
+       end do
+    end do
+
+  end subroutine compute_partmc_emission_inputs_sector
+
+  ! Sector-resolved version of partmc_interface_e3sm_emissions.
+  subroutine partmc_interface_e3sm_emissions_sector(emissions, geom_mean_diam, &
+       sigma_emode, num_fluxes, vol_frac)
+
+    ! Emissions data structure to pass to PartMC.
+    type(aero_dist_t), intent(inout) :: emissions
+    ! Geometric mean diameter of each sector mode. Not necesarily the same
+    ! as the parent MAM mode diameter.
+    real(kind=dp), intent(in) :: geom_mean_diam(:)   ! (n_emit_mode)
+    ! Geometric standard deviation of each sector mode.
+    real(kind=dp), intent(in) :: sigma_emode(:)      ! (n_emit_mode)
+    ! Number flux of each sector mode.
+    real(kind=dp), intent(in) :: num_fluxes(:)       ! (n_emit_mode)
+    ! Volume fraction of each PartMC species in each sector mode. Indexed by
+    ! PartMC species index, not per-mode species index so no per-mode species
+    ! mapping needed.
+    real(kind=dp), intent(in) :: vol_frac(:,:)       ! (n_emit_mode, n_aero_spec)
+
+    integer :: i_mode, n_aero_spec
+    character(len=AERO_MODE_NAME_LEN) :: mode_name
+    character(len=SPEC_LINE_MAX_VAR_LEN) :: weight_class_name
+
+    if (allocated(emissions%mode)) deallocate(emissions%mode)
+    allocate(emissions%mode(n_emit_mode))
+
+    n_aero_spec = aero_data_n_spec(aero_data)
+
+    do i_mode = 1, n_emit_mode
+       mode_name = sector_modes(i_mode)%name
+       emissions%mode(i_mode)%name = mode_name
+       emissions%mode(i_mode)%type = AERO_MODE_TYPE_LOG_NORMAL
+       emissions%mode(i_mode)%source = aero_data_source_by_name(aero_data, mode_name)
+       weight_class_name = mode_name
+       emissions%mode(i_mode)%weight_class = &
+            aero_data_weight_class_by_name(aero_data, weight_class_name)
+       emissions%mode(i_mode)%char_radius = geom_mean_diam(i_mode) / 2.0d0
+       emissions%mode(i_mode)%log10_std_dev_radius = log10(sigma_emode(i_mode))
+       emissions%mode(i_mode)%num_conc = num_fluxes(i_mode)
+
+       allocate(emissions%mode(i_mode)%vol_frac(n_aero_spec))
+       allocate(emissions%mode(i_mode)%vol_frac_std(n_aero_spec))
+       emissions%mode(i_mode)%vol_frac(:) = vol_frac(i_mode, :)
+
+       ! Set these to zero.
+       emissions%mode(i_mode)%vol_frac_std(:) = 0.0d0
+       emissions%mode(i_mode)%sample_radius = [ real(kind=dp) :: ]
+       emissions%mode(i_mode)%sample_num_conc = [ real(kind=dp) :: ]
+    end do
+
+  end subroutine partmc_interface_e3sm_emissions_sector
 
 end module mo_partmc_interface

--- a/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
+++ b/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
@@ -22,7 +22,10 @@ module mo_partmc_interface
     type(gas_data_t) :: gas_data
     type(gas_state_t) :: gas_state
     type(aero_data_t) :: aero_data
-    type(aero_state_t) :: aero_state
+    type aero_state_array_t
+       type(aero_state_t), allocatable, dimension(:,:) :: aero_state
+    end type aero_state_array_t
+    type(aero_state_array_t), allocatable, dimension(:) :: aero_state_array
     type(scenario_t) :: scenario
     type(env_state_t) :: env_state
     type(env_state_t) :: env_state_init
@@ -313,24 +316,24 @@ end subroutine compute_partmc_emission_inputs
 
     ! Create a single mode to sample
     ! TODO: Replace with something informed by initial conditions
-    allocate(aero_dist_init%mode(1))
-    aero_dist_init%mode(1)%name = "TEST"
-    aero_dist_init%mode(1)%type = AERO_MODE_TYPE_LOG_NORMAL
-    aero_dist_init%mode(1)%source = aero_data_source_by_name(aero_data, &
-         aero_dist_init%mode(1)%name)
-    weight_class_name = aero_dist_init%mode(1)%name
-    aero_dist_init%mode(1)%weight_class = aero_data_weight_class_by_name(aero_data, &
-            weight_class_name)
-    aero_dist_init%mode(1)%char_radius = 1.0d-8
-    aero_dist_init%mode(1)%log10_std_dev_radius = log10(1.6d0)
-    aero_dist_init%mode(1)%num_conc = 1.0d9
-    allocate(aero_dist_init%mode(1)%vol_frac(aero_data_n_spec(aero_data)))
-    allocate(aero_dist_init%mode(1)%vol_frac_std(aero_data_n_spec(aero_data)))
-    aero_dist_init%mode(1)%vol_frac = 1.0d0 / 20
-    aero_dist_init%mode(1)%vol_frac_std = 0.0d0
-
-    aero_dist_init%mode(1)%sample_radius = [ real(kind=dp) :: ]
-    aero_dist_init%mode(1)%sample_num_conc = [ real(kind=dp) :: ]
+!    allocate(aero_dist_init%mode(1))
+!    aero_dist_init%mode(1)%name = "TEST"
+!    aero_dist_init%mode(1)%type = AERO_MODE_TYPE_LOG_NORMAL
+!    aero_dist_init%mode(1)%source = aero_data_source_by_name(aero_data, &
+!         aero_dist_init%mode(1)%name)
+!    weight_class_name = aero_dist_init%mode(1)%name
+!    aero_dist_init%mode(1)%weight_class = aero_data_weight_class_by_name(aero_data, &
+!            weight_class_name)
+!    aero_dist_init%mode(1)%char_radius = 1.0d-8
+!    aero_dist_init%mode(1)%log10_std_dev_radius = log10(1.6d0)
+!    aero_dist_init%mode(1)%num_conc = 1.0d9
+!    allocate(aero_dist_init%mode(1)%vol_frac(aero_data_n_spec(aero_data)))
+!    allocate(aero_dist_init%mode(1)%vol_frac_std(aero_data_n_spec(aero_data)))
+!    aero_dist_init%mode(1)%vol_frac = 1.0d0 / 20
+!    aero_dist_init%mode(1)%vol_frac_std = 0.0d0
+!
+!    aero_dist_init%mode(1)%sample_radius = [ real(kind=dp) :: ]
+!    aero_dist_init%mode(1)%sample_num_conc = [ real(kind=dp) :: ]
 
     ! run_part_opt general settings
     run_part_opt%output_prefix = "./partmc_output/urban_plume"
@@ -373,46 +376,126 @@ end subroutine compute_partmc_emission_inputs
 
   end subroutine spec_file_read_run_part_eam
 
-  subroutine partmc_mam_inti()
+  subroutine partmc_mam_inti(phys_state, species_class)
    use mo_tracname, only : solsym
    use cam_history,  only : addfld
    use cam_history_support, only: add_hist_coord
    use mo_chem_utls,        only : get_spc_ndx
-   use rad_constituents, only: rad_cnst_get_info
+   use rad_constituents, only: rad_cnst_get_info, rad_cnst_get_mode_num_idx
+   use constituents,     only: pcnst
+   use physconst,    only: spec_class_aerosol, spec_class_gas
+   use physics_types,    only : physics_state
+   use mo_gas_phase_chemdr, only : map2chm
+   use modal_aero_data, only: ntot_amode, modename_amode, sigmag_amode, &
+       nspec_amode, numptr_amode, lmassptr_amode
+   use mpi
 
    implicit none
-   integer :: i, n_species, n_aero_species, n_times, i_spec,i_mode, nspec
 
+   type(physics_state), intent(in) :: phys_state(begchunk:endchunk)
+   integer, dimension(:), intent(in) :: species_class
+
+   integer :: i, n_species, n_aero_species, i_spec,i_mode, nspec
+   integer :: ncol, kk, icol, ichunk, idx_chm, num_idx, rank
+   integer :: n_gas_species, nfs
+   integer :: ierr
    character(len=100) :: file_name
    type(spec_file_t) :: file
    type(spec_file_t) :: sub_file
    type(aero_dist_t) :: aero_dist_init
+   character(len=SPEC_LINE_MAX_VAR_LEN) :: weight_class_name
 
+   call mpi_comm_rank(MPI_COMM_WORLD, rank, ierr)
 
-   print*, 'in partmc initialization (new)'
+   print*, 'MPI rank: ', rank, 'chunk start: ', begchunk, 'chunk end:', endchunk
 
-  n_species=46 ! get from eam
+   ! Allocate aero_state for each column of each chunk
+   allocate(aero_state_array(begchunk:endchunk))
+   do i = begchunk, endchunk
+      ncol = phys_state(i)%ncol
+      allocate(aero_state_array(i)%aero_state(ncol,pver))
+   end do
+
   ! n_aero_species=7 ! get from eam
-  n_times=1
-  call ensure_string_array_size(gas_data%name, n_species)
-  call gas_state_set_size(gas_state, n_species)
-
-  do i = 1,n_species
-    gas_data%name(i) = solsym(i)
+  ! Get number of actual (active) gas species.
+  ! gas_pncst is "gas" species which apparently is not just gases.
+  n_gas_species = 0
+  do i =1,pcnst
+     if (species_class(i) == spec_class_gas) then
+        n_gas_species = n_gas_species + 1
+     end if
   end do
+
+  if (masterproc) then
+     print*, 'number of active (?) gas species', n_gas_species
+!     print*, 'number of fixed gas species if we need it', nfs
+  end if
+
+  call ensure_string_array_size(gas_data%name, n_gas_species)
+  call gas_state_set_size(gas_state, n_gas_species)
+
+  do i = 1,n_gas_species
+     gas_data%name(i) = solsym(i)
+  end do
+
+  if (masterproc) then
+     write(*,*) 'PartMC gas_data names'
+     do i =1, gas_data_n_spec(gas_data)
+        write(*,*) trim(gas_data%name(i))
+     end do
+  end if
 
   call spec_file_read_run_part_eam(run_part_opt, aero_data, &
        env_state_init, &
        aero_dist_init, &
        n_part, rand_init)
+!  call aero_state_zero(aero_state)
+!  call aero_state_set_weight(aero_state, aero_data, &
+!       AERO_STATE_WEIGHT_FLAT_SOURCE)
+!  call aero_state_set_n_part_ideal(aero_state, n_part)
+!  call aero_state_add_aero_dist_sample(aero_state, aero_data, &
+!       aero_dist_init, 1d0, 1d0, 0d0, run_part_opt%allow_doubling, &
+!       run_part_opt%allow_halving)
 
-  call aero_state_zero(aero_state)
-  call aero_state_set_weight(aero_state, aero_data, &
-       AERO_STATE_WEIGHT_FLAT_SOURCE)
-  call aero_state_set_n_part_ideal(aero_state, n_part)
-  call aero_state_add_aero_dist_sample(aero_state, aero_data, &
-       aero_dist_init, 1d0, 1d0, 0d0, run_part_opt%allow_doubling, &
-       run_part_opt%allow_halving)
+    allocate(aero_dist_init%mode(ntot_amode))
+    do i_mode = 1,ntot_amode
+       aero_dist_init%mode(i_mode)%name =  modename_amode(i_mode)
+       aero_dist_init%mode(i_mode)%type = AERO_MODE_TYPE_LOG_NORMAL
+       aero_dist_init%mode(i_mode)%source = aero_data_source_by_name(aero_data, &
+            aero_dist_init%mode(i_mode)%name)
+       weight_class_name = aero_dist_init%mode(i_mode)%name
+       aero_dist_init%mode(i_mode)%weight_class = aero_data_weight_class_by_name(aero_data, &
+            weight_class_name)
+       aero_dist_init%mode(i_mode)%log10_std_dev_radius = log10(sigmag_amode(i_mode))
+       allocate(aero_dist_init%mode(i_mode)%vol_frac(aero_data_n_spec(aero_data)))
+       allocate(aero_dist_init%mode(i_mode)%vol_frac_std(aero_data_n_spec(aero_data)))
+       aero_dist_init%mode(i_mode)%vol_frac_std = 0.0d0
+       aero_dist_init%mode(i_mode)%sample_radius = [ real(kind=dp) :: ]
+       aero_dist_init%mode(i_mode)%sample_num_conc = [ real(kind=dp) :: ]
+    end do
+
+    do ichunk = begchunk,endchunk
+    do kk = 1,pver
+    do icol = 1, ncol
+       do i_mode = 1,ntot_amode
+          num_idx =  numptr_amode(i_mode)
+          idx_chm = map2chm(num_idx)
+          call rad_cnst_get_mode_num_idx(i_mode, num_idx)
+          aero_dist_init%mode(i_mode)%char_radius = 1.0d-8
+          aero_dist_init%mode(i_mode)%vol_frac = 1.0d0 / 20
+          aero_dist_init%mode(i_mode)%num_conc = 1e6 + 1e6*phys_state(ichunk)%lon(icol) ** 2
+!          aero_dist_init%mode(i_mode)%num_conc = phys_state(ichunk)%q(icol,kk,idx_chm)
+       end do
+       call aero_state_zero(aero_state_array(ichunk)%aero_state(icol,kk))
+       call aero_state_set_weight(aero_state_array(ichunk)%aero_state(icol,kk), aero_data, &
+            AERO_STATE_WEIGHT_FLAT_SOURCE)
+       call aero_state_set_n_part_ideal(aero_state_array(ichunk)%aero_state(icol,kk), n_part)
+       call aero_state_add_aero_dist_sample(aero_state_array(ichunk)%aero_state(icol,kk), &
+            aero_data, aero_dist_init, 1d0, 1d0, 0d0, run_part_opt%allow_doubling, &
+            run_part_opt%allow_halving)
+    end do
+    end do
+    end do
 
   env_state = env_state_init
 
@@ -449,6 +532,7 @@ end subroutine compute_partmc_emission_inputs
     write(102,*) '-----------------------------------------'
   endif
 
+  print*, 'done with PartMC initialization'
 
   end subroutine partmc_mam_inti
 
@@ -511,10 +595,8 @@ end subroutine compute_partmc_emission_inputs
     ! emission inputs
     geom_mean_diameter(:,:)=0
     num_fluxes(:,:)=0
-    call compute_partmc_emission_inputs(cflx, ncol,geom_mean_diameter, sigma_mam, num_fluxes, volume_fractions)
-
-    ! FIXME: Move inside the loop over cells.
-    call partmc_interface_e3sm_emissions(state, emissions)
+    call compute_partmc_emission_inputs(cflx, ncol, geom_mean_diameter, &
+         sigma_mam, num_fluxes, volume_fractions)
 
     do kk = 1,pver
       do icol = 1, ncol
@@ -555,27 +637,41 @@ end subroutine compute_partmc_emission_inputs
         n_coag = 0
         n_samp = 0
         n_emit = 0
+        call partmc_interface_e3sm_emissions(state, emissions, &
+           geom_mean_diameter(icol,:), sigma_mam, num_fluxes(icol,:), volume_fractions(icol, : , :))
+
+
+        if (masterproc) then
+           if (icol == 1) then
+           print*, kk, env_state%temp, env_state%pressure,env_state%height,  env_state%altitude
+           end if
+        end if 
+
         do i_time = 1,n_time
 
            ! Aerosol emissions
-           emission_rate_scale = 1.0d0
-           characteristic_factor = 3600.0d0 / run_part_opt%del_t
-           p = emission_rate_scale * run_part_opt%del_t / env_state%height
-           call aero_state_add_aero_dist_sample(aero_state, aero_data, &
-               emissions, p, characteristic_factor, env_state%elapsed_time, &
-               run_part_opt%allow_doubling, run_part_opt%allow_halving, n_emit)
+           if (kk == pver) then
+              emission_rate_scale = 1.0d0
+              characteristic_factor = 3600.0d0 / run_part_opt%del_t
+              p = emission_rate_scale * run_part_opt%del_t / env_state%height
+              call aero_state_add_aero_dist_sample(aero_state_array(lchnk)%aero_state(icol,kk), &
+                   aero_data,  emissions, p, characteristic_factor, env_state%elapsed_time, & 
+                   run_part_opt%allow_doubling, run_part_opt%allow_halving, n_emit)
+           end if
 
            ! Coagulation
-           call mc_coag(run_part_opt%coag_kernel_type, env_state, &
-                  aero_data, aero_state, run_part_opt%del_t, n_samp, n_coag)
+           ! DISABLED
+           ! call mc_coag(run_part_opt%coag_kernel_type, env_state, &
+           !      aero_data, aero_state, run_part_opt%del_t, n_samp, n_coag)
 
            ! Rebalance
-           call aero_state_rebalance(aero_state, aero_data, &
+           call aero_state_rebalance(aero_state_array(lchnk)%aero_state(icol,kk), aero_data, &
                 run_part_opt%allow_doubling, &
                 run_part_opt%allow_halving, initial_state_warning=.false.)
 
         end do
-        call write_nc_aero_state(aero_state,aero_particle_mass_out, &
+        call write_nc_aero_state(aero_state_array(lchnk)%aero_state(icol,kk), &
+             aero_particle_mass_out, &
                             aero_num_conc_out, &
                             number_conc_out, &
                             icol, kk)
@@ -648,12 +744,18 @@ end subroutine compute_partmc_emission_inputs
 
   end subroutine write_nc_aero_state
 
-  subroutine partmc_interface_e3sm_emissions(state, emissions)
+  subroutine partmc_interface_e3sm_emissions(state, emissions, geom_mean_diam, &
+      sigma, num_fluxes, vol_frac)
     use physics_types,    only : physics_state
 
     implicit none
     type(physics_state), intent(in):: state
     type(aero_dist_t), intent(inout) :: emissions
+
+    real(kind=dp), intent(in) ::  geom_mean_diam(nmodes)
+    real(kind=dp), intent(in) ::  sigma(nmodes)
+    real(kind=dp), intent(in) ::  num_fluxes(nmodes)
+    real(kind=dp), intent(in) ::  vol_frac(nmodes, nspec_max_modes)
 
     integer :: i_mode
     character(len=AERO_MODE_NAME_LEN) :: mode_name

--- a/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
+++ b/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
@@ -244,7 +244,6 @@ end subroutine compute_partmc_emission_inputs
 
   subroutine spec_file_read_run_part_eam(run_part_opt, aero_data, &
        env_state_init, &
-       aero_dist_init, &
        n_part, rand_init)
 
     !> Monte Carlo options.
@@ -253,8 +252,6 @@ end subroutine compute_partmc_emission_inputs
     type(aero_data_t), intent(inout) :: aero_data
     !> Initial environmental state.
     type(env_state_t), intent(inout) :: env_state_init
-    !> Initial aerosol distribution.
-    type(aero_dist_t), intent(inout) :: aero_dist_init
     !> Ideal number of computational particles.
     real(kind=dp), intent(inout) :: n_part
     !> Random number generator seed.
@@ -284,7 +281,7 @@ end subroutine compute_partmc_emission_inputs
          "BC    ", "H2O   "]
     character(len=SPEC_LINE_MAX_VAR_LEN) :: weight_class_name
 
-    n_part = 10
+    n_part = 50
 
     env_state_init%elapsed_time = 0d0
 
@@ -314,27 +311,6 @@ end subroutine compute_partmc_emission_inputs
     call aero_data_set_mosaic_map(aero_data)
 
     call fractal_set_spherical(aero_data%fractal)
-
-    ! Create a single mode to sample
-    ! TODO: Replace with something informed by initial conditions
-!    allocate(aero_dist_init%mode(1))
-!    aero_dist_init%mode(1)%name = "TEST"
-!    aero_dist_init%mode(1)%type = AERO_MODE_TYPE_LOG_NORMAL
-!    aero_dist_init%mode(1)%source = aero_data_source_by_name(aero_data, &
-!         aero_dist_init%mode(1)%name)
-!    weight_class_name = aero_dist_init%mode(1)%name
-!    aero_dist_init%mode(1)%weight_class = aero_data_weight_class_by_name(aero_data, &
-!            weight_class_name)
-!    aero_dist_init%mode(1)%char_radius = 1.0d-8
-!    aero_dist_init%mode(1)%log10_std_dev_radius = log10(1.6d0)
-!    aero_dist_init%mode(1)%num_conc = 1.0d9
-!    allocate(aero_dist_init%mode(1)%vol_frac(aero_data_n_spec(aero_data)))
-!    allocate(aero_dist_init%mode(1)%vol_frac_std(aero_data_n_spec(aero_data)))
-!    aero_dist_init%mode(1)%vol_frac = 1.0d0 / 20
-!    aero_dist_init%mode(1)%vol_frac_std = 0.0d0
-!
-!    aero_dist_init%mode(1)%sample_radius = [ real(kind=dp) :: ]
-!    aero_dist_init%mode(1)%sample_num_conc = [ real(kind=dp) :: ]
 
     ! run_part_opt general settings
     run_part_opt%output_prefix = "./partmc_output/urban_plume"
@@ -448,15 +424,7 @@ end subroutine compute_partmc_emission_inputs
 
   call spec_file_read_run_part_eam(run_part_opt, aero_data, &
        env_state_init, &
-       aero_dist_init, &
        n_part, rand_init)
-!  call aero_state_zero(aero_state)
-!  call aero_state_set_weight(aero_state, aero_data, &
-!       AERO_STATE_WEIGHT_FLAT_SOURCE)
-!  call aero_state_set_n_part_ideal(aero_state, n_part)
-!  call aero_state_add_aero_dist_sample(aero_state, aero_data, &
-!       aero_dist_init, 1d0, 1d0, 0d0, run_part_opt%allow_doubling, &
-!       run_part_opt%allow_halving)
 
     allocate(aero_dist_init%mode(ntot_amode))
     do i_mode = 1,ntot_amode
@@ -484,7 +452,7 @@ end subroutine compute_partmc_emission_inputs
           call rad_cnst_get_mode_num_idx(i_mode, num_idx)
           aero_dist_init%mode(i_mode)%char_radius = 1.0d-8
           aero_dist_init%mode(i_mode)%vol_frac = 1.0d0 / 20
-          aero_dist_init%mode(i_mode)%num_conc = 1e6 + 1e6*phys_state(ichunk)%lon(icol) ** 2
+          aero_dist_init%mode(i_mode)%num_conc = 1e6 !+ 1e6*phys_state(ichunk)%lon(icol) ** 2
 !          aero_dist_init%mode(i_mode)%num_conc = phys_state(ichunk)%q(icol,kk,idx_chm)
        end do
        call aero_state_zero(aero_state_array(ichunk)%aero_state(icol,kk))
@@ -533,8 +501,6 @@ end subroutine compute_partmc_emission_inputs
     write(102,*) '-----------------------------------------'
   endif
 
-  print*, 'done with PartMC initialization'
-
   end subroutine partmc_mam_inti
 
   subroutine partmc_mam_invoke(state, cflx, dt)
@@ -558,6 +524,7 @@ end subroutine compute_partmc_emission_inputs
     real(kind=dp) ::  volume_fractions(pcols, nmodes, nspec_max_modes)
 
     integer ::  n_samp, n_coag, i_time, n_time, n_emit,nmodes
+    integer :: i_mode
     real(kind=dp) :: emission_rate_scale, p
     real(kind=dp) :: characteristic_factor
     type(aero_dist_t) :: emissions
@@ -638,11 +605,22 @@ end subroutine compute_partmc_emission_inputs
         n_emit = 0
         call partmc_interface_e3sm_emissions(state, emissions, &
            geom_mean_diameter(icol,:), sigma_mam, num_fluxes(icol,:), volume_fractions(icol, : , :))
-
-
         if (masterproc) then
            if (icol == 1) then
-           print*, kk, env_state%temp, env_state%pressure,env_state%height,  env_state%altitude
+           write(102,*) '-----------------------------------------'
+           write(102,*) 'grid cell | temperature | pressure | box height | altitude'
+           write(102,*) kk, env_state%temp, env_state%pressure,env_state%height,  env_state%altitude
+           write(102,*) '-----------------------------------------'
+           end if
+           if (kk == pver) then
+              write(102,*) '-----------------------------------------'
+              write(102,*) 'i_mode | radius | log10sigma | number flux'
+              do i_mode = 1,n_emit_mode
+                 write(102,*) i_mode, emissions%mode(i_mode)%char_radius, &
+                         emissions%mode(i_mode)%log10_std_dev_radius, &
+                         emissions%mode(i_mode)%num_conc
+              end do
+              write(102,*) '-----------------------------------------'
            end if
         end if 
 
@@ -772,9 +750,9 @@ end subroutine compute_partmc_emission_inputs
        weight_class_name = emissions%mode(i_mode)%name
        emissions%mode(i_mode)%weight_class = aero_data_weight_class_by_name(aero_data, &
                weight_class_name)
-       emissions%mode(i_mode)%char_radius = 1.0d-8
-       emissions%mode(i_mode)%log10_std_dev_radius = log10(1.6d0)
-       emissions%mode(i_mode)%num_conc = 1.0d6
+       emissions%mode(i_mode)%char_radius = geom_mean_diam(i_mode) / 2.0d0
+       emissions%mode(i_mode)%log10_std_dev_radius = log10(sigma(i_mode))
+       emissions%mode(i_mode)%num_conc = num_fluxes(i_mode)
        allocate(emissions%mode(i_mode)%vol_frac(aero_data_n_spec(aero_data)))
        allocate(emissions%mode(i_mode)%vol_frac_std(aero_data_n_spec(aero_data)))
        emissions%mode(i_mode)%vol_frac = 1.0d0 / 20

--- a/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
+++ b/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
@@ -248,6 +248,7 @@ subroutine compute_partmc_emission_inputs(cflx, ncol, geom_mean_diameter, std_ma
 
 end subroutine compute_partmc_emission_inputs
 
+  ! Sets properties of the PartMC run. For now, hardcoded.
   subroutine spec_file_read_run_part_eam(run_part_opt, &
        env_state_init, &
        n_part_ideal, rand_init)
@@ -314,6 +315,7 @@ end subroutine compute_partmc_emission_inputs
 
   end subroutine spec_file_read_run_part_eam
 
+  ! Initializes the data structures of PartMC.
   subroutine partmc_mam_inti(phys_state, species_class)
    use mo_tracname, only : solsym
    use cam_history,  only : addfld
@@ -415,30 +417,15 @@ end subroutine compute_partmc_emission_inputs
        aero_dist_init%mode(i_mode)%sample_num_conc = [ real(kind=dp) :: ]
     end do
 
+    ! Set the weighting schemes and number of ideal particles for each aero_state
     do ichunk = begchunk,endchunk
     ncol = phys_state(ichunk)%ncol
     do kk = 1,pver
     do icol = 1, ncol
-!       do i_mode = 1,ntot_amode
-!          num_idx =  numptr_amode(i_mode)
-!          idx_chm = map2chm(num_idx)
-!          call rad_cnst_get_mode_num_idx(i_mode, num_idx)
-!          aero_dist_init%mode(i_mode)%char_radius = 1.0d-8
-!          aero_dist_init%mode(i_mode)%vol_frac = 1.0d0 / 20
-!          aero_dist_init%mode(i_mode)%num_conc = 1e6
-!          !if (masterproc)
-!             !write(102,*) i_mode, num_idx, idx_chm, phys_state(ichunk)%q(icol,kk,idx_chm), &
-!                  !phys_state(ichunk)%q(icol,kk,num_idx)
-!          !endif
-!          !aero_dist_init%mode(i_mode)%num_conc = phys_state(ichunk)%q(icol,kk,idx_chm)
-!       end do
        call aero_state_zero(aero_state_array(ichunk)%aero_state(icol,kk))
        call aero_state_set_weight(aero_state_array(ichunk)%aero_state(icol,kk), aero_data, &
             AERO_STATE_WEIGHT_FLAT_SOURCE)
        call aero_state_set_n_part_ideal(aero_state_array(ichunk)%aero_state(icol,kk), n_part_ideal)
-!       call aero_state_add_aero_dist_sample(aero_state_array(ichunk)%aero_state(icol,kk), &
-!            aero_data, aero_dist_init, 1d0, 1d0, 0d0, run_part_opt%allow_doubling, &
-!            run_part_opt%allow_halving)
     end do
     end do
     end do
@@ -484,6 +471,7 @@ end subroutine compute_partmc_emission_inputs
 
   end subroutine partmc_mam_inti
 
+  ! Solves a time step dt of PartMC.
   subroutine partmc_mam_invoke(state, cflx, dt)
     use physics_types,    only : physics_state
     use cam_history,       only : outfld

--- a/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
+++ b/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
@@ -248,10 +248,6 @@ end subroutine compute_partmc_emission_inputs
        env_state_init, &
        n_part_ideal, rand_init)
 
-    use rad_constituents, only: rad_cnst_get_info, rad_cnst_get_aer_props
-    use modal_aero_data, only: &
-        lspectype_amode
-
     !> Monte Carlo options.
     type(run_part_opt_t), intent(inout) :: run_part_opt
     !> Initial environmental state.
@@ -261,32 +257,10 @@ end subroutine compute_partmc_emission_inputs
     !> Random number generator seed.
     integer, intent(out) :: rand_init
 
-    integer :: i_repeat, i_group
-    logical :: read_aero_weight_classes
-    character(len=PMC_MAX_FILENAME_LEN) :: restart_filename
-    integer :: dummy_index, dummy_i_repeat
     integer :: dummy
-    real(kind=dp) :: dummy_time, dummy_del_t
-    character(len=PMC_MAX_FILENAME_LEN) :: sub_filename
-    type(spec_file_t) :: sub_file
-    character(len=PMC_MAX_FILENAME_LEN) :: camp_config_filename
+    integer :: i_mode
     character(len=AERO_MODE_NAME_LEN) :: mode_name
-
-    integer, parameter :: n_aero_spec = 20
-    integer, parameter :: n_gas_spec = 77
-    integer :: n_swbands
-    integer :: i_spec, i_mode
-    integer :: m, l
-    integer :: n_spec
-    real(kind=dp) :: density, hygro
-    character(AERO_NAME_LEN), parameter, dimension(n_aero_spec) :: &
-         mosaic_spec_name = [ &
-         "SO4   ", "NO3   ", "Cl    ", "NH4   ", "MSA   ", "ARO1  ", &
-         "ARO2  ", "ALK1  ", "OLE1  ", "API1  ", "API2  ", "LIM1  ", &
-         "LIM2  ", "CO3   ", "Na    ", "Ca    ", "OIN   ", "OC    ", &
-         "BC    ", "H2O   "]
     character(len=SPEC_LINE_MAX_VAR_LEN) :: weight_class_name
-    character(len=20):: aername
 
     n_part_ideal = 50
 
@@ -355,14 +329,11 @@ end subroutine compute_partmc_emission_inputs
    type(physics_state), intent(in) :: phys_state(begchunk:endchunk)
    integer, dimension(:), intent(in) :: species_class
 
-   integer :: i, n_species, n_aero_species, i_spec,i_mode, nspec
+   integer :: i, i_spec, i_mode, nspec
    integer :: ncol, kk, icol, ichunk, idx_chm, num_idx
-   integer :: n_gas_species, nfs
+   integer :: n_gas_species
    integer :: gas_species_idx(pcnst)
    integer :: rank, ierr ! Remove when debugging of processor removed
-   character(len=100) :: file_name
-   type(spec_file_t) :: file
-   type(spec_file_t) :: sub_file
    type(aero_dist_t) :: aero_dist_init
    character(len=SPEC_LINE_MAX_VAR_LEN) :: weight_class_name
 
@@ -511,9 +482,8 @@ end subroutine compute_partmc_emission_inputs
     real(kind=dp),       intent(in) :: cflx(pcols,pcnst)              ! constituent surface flux (kg/m^2/s)
     real(kind=dp),            intent(in)    :: dt              ! time step
 
-    integer :: i, n_species, icol, kk, lchnk, ncol, n_aero_species
+    integer :: i, icol, kk, lchnk, ncol
     real(kind=dp) ::  aero_particle_mass_out(pcols, pver,  n_part_max,n_aero_sp_max)
-    real(kind=dp) ::  aero_component_len_out(pcols, pver,  n_part_max)
     real(kind=dp) ::  aero_num_conc_out(pcols, pver,  n_part_max)
     real(kind=dp) ::  number_conc_out(pcols, pver)
     real(kind=dp) ::  geom_mean_diameter(pcols, nmodes)
@@ -527,8 +497,6 @@ end subroutine compute_partmc_emission_inputs
     real(kind=dp) :: characteristic_factor
     type(aero_dist_t) :: emissions
 
-    !FIXME: get n_species this values from eam
-    n_species= gas_data_n_spec(gas_data)
     !FIXME: we must pass a delta time factor
     n_time = 30
     run_part_opt%del_t = dt / n_time
@@ -642,8 +610,9 @@ end subroutine compute_partmc_emission_inputs
 
            ! Coagulation
            if (run_part_opt%do_coagulation) then
-              call mc_coag(run_part_opt%coag_kernel_type, env_state, &
-                   aero_data, aero_state, run_part_opt%del_t, n_samp, n_coag)
+              call mc_coag(run_part_opt%coag_kernel_type, env_state, aero_data, &
+                   aero_state_array(lchnk)%aero_state(icol,kk), run_part_opt%del_t, &
+                   n_samp, n_coag)
            end if
 
            ! Rebalance
@@ -689,15 +658,6 @@ end subroutine compute_partmc_emission_inputs
 
   real(kind=dp) :: aero_particle_mass(aero_state_n_part(aero_state), &
          aero_data_n_spec(aero_data))
-  integer :: aero_component_len(aero_state_n_part(aero_state))
-  integer :: array_position, i_comp, next_start_component_ind
-  integer :: aero_component_particle_num(aero_state_total_n_components( &
-         aero_state))
-  integer :: aero_component_source_num(aero_state_total_n_components( &
-         aero_state))
-  real(kind=dp) :: aero_component_create_time( &
-         aero_state_total_n_components(aero_state))
-  integer :: aero_component_start_ind(aero_state_n_part(aero_state))
   real(kind=dp) :: aero_num_conc(aero_state_n_part(aero_state))
 
   n_part=aero_state_n_part(aero_state)

--- a/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
+++ b/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
@@ -211,16 +211,16 @@ subroutine compute_partmc_emission_inputs(cflx, ncol, geom_mean_diameter, std_ma
 
 
   ! Loop over modes to compute properties
-  geom_mean_diameter(:,:)=0.0
+  geom_mean_diameter(:,:) = 0.0d0
   do n = 1, nmodes
     ! Initialize dry volume
-    dryvol(:) = 0.0
+    dryvol(:) = 0.0d0
 
     ! Get mode properties
     call rad_cnst_get_mode_props(list_idx, n, sigmag=sigmag)
     std_mam(n) = sigmag
     alnsg = log(sigmag)
-    dumfac = exp(4.5 * alnsg**2) * pi / 6.0
+    dumfac = exp(4.5d0 * alnsg**2) * pi / 6.0d0
 
     ! Get number flux index
     call rad_cnst_get_mode_num_idx(n, num_idx)
@@ -241,9 +241,9 @@ subroutine compute_partmc_emission_inputs(cflx, ncol, geom_mean_diameter, std_ma
     do ispec = 1, nspec
       call rad_cnst_get_mam_mmr_idx(n, ispec, spec_idx)
       call rad_cnst_get_aer_props(list_idx, n, ispec, density_aer=specdens)
-      dummwdens = 1.0 / specdens
+      dummwdens = 1.0d0 / specdens
       do icol = 1,ncol
-        dryvol(icol) = dryvol(icol) + max(0.0, cflx(icol, spec_idx)) * dummwdens
+        dryvol(icol) = dryvol(icol) + max(0.0d0, cflx(icol, spec_idx)) * dummwdens
       end do
     end do
 
@@ -259,14 +259,14 @@ subroutine compute_partmc_emission_inputs(cflx, ncol, geom_mean_diameter, std_ma
   end do
 
   ! Compute volume fractions
-  volume_fractions(:, :, :) =0.0
-  sum_vf_per_mode(:,:) = 0.0
+  volume_fractions(:, :, :) = 0.0d0
+  sum_vf_per_mode(:,:) = 0.0d0
   do n = 1, nmodes
     call rad_cnst_get_info(list_idx, n, nspec=nspec)
     do ispec = 1, nspec
       call rad_cnst_get_mam_mmr_idx(n, ispec, spec_idx)
       call rad_cnst_get_aer_props(list_idx, n, ispec, density_aer=specdens)
-      dummwdens = 1.0 / specdens
+      dummwdens = 1.0d0 / specdens
       do icol = 1,ncol
         volume_fractions(icol, n, ispec) =  cflx(icol, spec_idx) * dummwdens
         sum_vf_per_mode(icol, n) = sum_vf_per_mode(icol, n) + volume_fractions(icol, n, ispec)
@@ -284,9 +284,9 @@ subroutine compute_partmc_emission_inputs(cflx, ncol, geom_mean_diameter, std_ma
       call rad_cnst_get_mam_mmr_idx(n, ispec, spec_idx)
       idx_chm = map2chm(spec_idx)
         if (idx_chm > 0) then
-          if (adv_mass(idx_chm) /= 0.0) then
+          if (adv_mass(idx_chm) /= 0.0d0) then
             do icol = 1,ncol
-              if (sum_vf_per_mode(icol, n) /= 0.0) then
+              if (sum_vf_per_mode(icol, n) /= 0.0d0) then
                 volume_fractions(icol, n, ispec) = volume_fractions(icol, n, ispec) / sum_vf_per_mode(icol, n)
               end if
             end do

--- a/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
+++ b/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
@@ -48,6 +48,10 @@ module mo_partmc_interface
     character(len=256), allocatable :: mam_num_names(:)
     character(len=256), allocatable :: mam_species_names(:,:)
     integer, allocatable :: mam_spec_to_partmc_spec(:,:)
+    ! Initial q values captured on first invoke (phys_state%q not valid at inti time)
+    real(kind=dp), allocatable :: q_init(:,:,:,:)  ! (begchunk:endchunk, pcols, pver, pcnst)
+    logical, allocatable :: q_init_saved(:)  ! (begchunk:endchunk)
+
 contains
 !-----------------------------------------------------------------------
   subroutine compute_nspec_max(nspec_max)
@@ -348,6 +352,12 @@ end subroutine compute_partmc_emission_inputs
       allocate(aero_state_array(i)%aero_state(ncol,pver))
    end do
 
+   ! Allocate storage for initial q (captured on first invoke, not here,
+   ! because phys_state%q is not yet populated at inti time)
+   allocate(q_init(begchunk:endchunk, pcols, pver, pcnst))
+   allocate(q_init_saved(begchunk:endchunk))
+   q_init_saved(:) = .false.
+
   ! n_aero_species=7 ! get from eam
   ! Get number of actual (active) gas species.
   ! gas_pncst is "gas" species which apparently is not just gases.
@@ -387,12 +397,13 @@ end subroutine compute_partmc_emission_inputs
        env_state_init, &
        n_part_ideal, rand_init)
 
+    ! Make initial condition modes exist
     allocate(aero_dist_init%mode(ntot_amode))
     do i_mode = 1,ntot_amode
        aero_dist_init%mode(i_mode)%name =  modename_amode(i_mode)
        aero_dist_init%mode(i_mode)%type = AERO_MODE_TYPE_LOG_NORMAL
        aero_dist_init%mode(i_mode)%source = aero_data_source_by_name(aero_data, &
-            aero_dist_init%mode(i_mode)%name)
+           aero_dist_init%mode(i_mode)%name)
        weight_class_name = aero_dist_init%mode(i_mode)%name
        aero_dist_init%mode(i_mode)%weight_class = aero_data_weight_class_by_name(aero_data, &
             weight_class_name)
@@ -408,26 +419,26 @@ end subroutine compute_partmc_emission_inputs
     ncol = phys_state(ichunk)%ncol
     do kk = 1,pver
     do icol = 1, ncol
-       do i_mode = 1,ntot_amode
-          num_idx =  numptr_amode(i_mode)
-          idx_chm = map2chm(num_idx)
-          call rad_cnst_get_mode_num_idx(i_mode, num_idx)
-          aero_dist_init%mode(i_mode)%char_radius = 1.0d-8
-          aero_dist_init%mode(i_mode)%vol_frac = 1.0d0 / 20
-          aero_dist_init%mode(i_mode)%num_conc = 1e6
-          !if (masterproc)
-             !write(102,*) i_mode, num_idx, idx_chm, phys_state(ichunk)%q(icol,kk,idx_chm), &
-                  !phys_state(ichunk)%q(icol,kk,num_idx)
-          !endif
-          !aero_dist_init%mode(i_mode)%num_conc = phys_state(ichunk)%q(icol,kk,idx_chm)
-       end do
+!       do i_mode = 1,ntot_amode
+!          num_idx =  numptr_amode(i_mode)
+!          idx_chm = map2chm(num_idx)
+!          call rad_cnst_get_mode_num_idx(i_mode, num_idx)
+!          aero_dist_init%mode(i_mode)%char_radius = 1.0d-8
+!          aero_dist_init%mode(i_mode)%vol_frac = 1.0d0 / 20
+!          aero_dist_init%mode(i_mode)%num_conc = 1e6
+!          !if (masterproc)
+!             !write(102,*) i_mode, num_idx, idx_chm, phys_state(ichunk)%q(icol,kk,idx_chm), &
+!                  !phys_state(ichunk)%q(icol,kk,num_idx)
+!          !endif
+!          !aero_dist_init%mode(i_mode)%num_conc = phys_state(ichunk)%q(icol,kk,idx_chm)
+!       end do
        call aero_state_zero(aero_state_array(ichunk)%aero_state(icol,kk))
        call aero_state_set_weight(aero_state_array(ichunk)%aero_state(icol,kk), aero_data, &
             AERO_STATE_WEIGHT_FLAT_SOURCE)
        call aero_state_set_n_part_ideal(aero_state_array(ichunk)%aero_state(icol,kk), n_part_ideal)
-       call aero_state_add_aero_dist_sample(aero_state_array(ichunk)%aero_state(icol,kk), &
-            aero_data, aero_dist_init, 1d0, 1d0, 0d0, run_part_opt%allow_doubling, &
-            run_part_opt%allow_halving)
+!       call aero_state_add_aero_dist_sample(aero_state_array(ichunk)%aero_state(icol,kk), &
+!            aero_data, aero_dist_init, 1d0, 1d0, 0d0, run_part_opt%allow_doubling, &
+!            run_part_opt%allow_halving)
     end do
     end do
     end do
@@ -478,6 +489,13 @@ end subroutine compute_partmc_emission_inputs
     use cam_history,       only : outfld
     use constituents,     only: pcnst
 
+   use mo_chem_utls,        only : get_spc_ndx
+   use rad_constituents, only: rad_cnst_get_info, rad_cnst_get_mode_num_idx
+   use physconst,    only: spec_class_aerosol, spec_class_gas
+   use mo_gas_phase_chemdr, only : map2chm
+   use modal_aero_data, only: ntot_amode, modename_amode, sigmag_amode, &
+       nspec_amode, numptr_amode, lmassptr_amode
+
     implicit none
     type(physics_state), intent(inout):: state
     real(kind=dp),       intent(in) :: cflx(pcols,pcnst)              ! constituent surface flux (kg/m^2/s)
@@ -497,6 +515,9 @@ end subroutine compute_partmc_emission_inputs
     real(kind=dp) :: emission_rate_scale, p
     real(kind=dp) :: characteristic_factor
     type(aero_dist_t) :: emissions
+    type(aero_dist_t) :: aero_dist_init
+    character(len=SPEC_LINE_MAX_VAR_LEN) :: weight_class_name
+    integer :: num_idx, idx_chm
 
     !FIXME: we must pass a delta time factor
     n_time = 30
@@ -506,6 +527,49 @@ end subroutine compute_partmc_emission_inputs
 
     lchnk = state%lchnk
     ncol  = state%ncol
+
+    ! Capture initial q on first invocation for this chunk.
+    ! (phys_state%q is not populated until d_p_coupling runs before the first
+    ! timestep, which is after partmc_mam_inti is called during phys_init.)
+    if (.not. q_init_saved(lchnk)) then
+      allocate(aero_dist_init%mode(ntot_amode))
+      do i_mode = 1,ntot_amode
+       aero_dist_init%mode(i_mode)%name =  modename_amode(i_mode)
+       aero_dist_init%mode(i_mode)%type = AERO_MODE_TYPE_LOG_NORMAL
+       aero_dist_init%mode(i_mode)%source = aero_data_source_by_name(aero_data, &
+            aero_dist_init%mode(i_mode)%name)
+       weight_class_name = aero_dist_init%mode(i_mode)%name
+       aero_dist_init%mode(i_mode)%weight_class = aero_data_weight_class_by_name(aero_data, &
+            weight_class_name)
+       aero_dist_init%mode(i_mode)%log10_std_dev_radius = log10(sigmag_amode(i_mode))
+       allocate(aero_dist_init%mode(i_mode)%vol_frac(aero_data_n_spec(aero_data)))
+       allocate(aero_dist_init%mode(i_mode)%vol_frac_std(aero_data_n_spec(aero_data)))
+       aero_dist_init%mode(i_mode)%vol_frac_std = 0.0d0
+       aero_dist_init%mode(i_mode)%sample_radius = [ real(kind=dp) :: ]
+       aero_dist_init%mode(i_mode)%sample_num_conc = [ real(kind=dp) :: ]
+       end do
+       do kk = 1,pver
+       do icol = 1,ncol
+          do i_mode = 1,ntot_amode
+          num_idx =  numptr_amode(i_mode)
+          idx_chm = map2chm(num_idx)
+          call rad_cnst_get_mode_num_idx(i_mode, num_idx)
+          aero_dist_init%mode(i_mode)%char_radius = 1.0d-8
+          aero_dist_init%mode(i_mode)%vol_frac = 1.0d0 / 20
+          aero_dist_init%mode(i_mode)%num_conc = 1e6
+          !if (masterproc)
+             !write(102,*) i_mode, num_idx, idx_chm, phys_state(ichunk)%q(icol,kk,idx_chm), &
+                  !phys_state(ichunk)%q(icol,kk,num_idx)
+          !endif
+          !aero_dist_init%mode(i_mode)%num_conc = phys_state(ichunk)%q(icol,kk,idx_chm)
+          end do
+       call aero_state_add_aero_dist_sample(aero_state_array(lchnk)%aero_state(icol,kk), &
+            aero_data, aero_dist_init, 1d0, 1d0, 0d0, run_part_opt%allow_doubling, &
+            run_part_opt%allow_halving)
+       end do
+       end do
+       q_init_saved(lchnk) = .true.
+    end if
 
     ! Output arrays
     aero_particle_mass_out(:,:,:,:)=-1000d0

--- a/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
+++ b/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
@@ -34,7 +34,8 @@ module mo_partmc_interface
     integer :: rand_init
     integer, parameter, public :: n_part_max = 100
     integer, parameter, public :: n_aero_sp_max = 25
-    integer, parameter, public :: n_emit_mode = 1
+    ! FIXME: Temporary set to fixed value 
+    integer, parameter, public :: n_emit_mode = 5 
     character, allocatable :: buffer(:)
     integer :: buffer_size, max_buffer_size
     integer :: position
@@ -585,8 +586,6 @@ end subroutine compute_partmc_emission_inputs
          write(102,*) '-----------------------------------------'
     endif
 
-    ! emissions
-
     ! FIXME: What time information does PartMC need here?
     env_state%start_time=0
     env_state%start_day=0
@@ -655,7 +654,7 @@ end subroutine compute_partmc_emission_inputs
               characteristic_factor = 3600.0d0 / run_part_opt%del_t
               p = emission_rate_scale * run_part_opt%del_t / env_state%height
               call aero_state_add_aero_dist_sample(aero_state_array(lchnk)%aero_state(icol,kk), &
-                   aero_data,  emissions, p, characteristic_factor, env_state%elapsed_time, & 
+                   aero_data,  emissions, p, characteristic_factor, env_state%elapsed_time, &
                    run_part_opt%allow_doubling, run_part_opt%allow_halving, n_emit)
            end if
 

--- a/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
+++ b/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
@@ -855,7 +855,7 @@ end subroutine compute_partmc_emission_inputs
           input_array(i_name) = aername
           density_array(i_name) = density 
           kappa_array(i_name) =  hygro
-          mw_array(i_name) = specmw_amode(l)
+          mw_array(i_name) = specmw_amode(lspectype_amode(l,m))
       end do
     end do
 

--- a/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
+++ b/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
@@ -49,7 +49,6 @@ module mo_partmc_interface
     character(len=256), allocatable :: mam_species_names(:,:)
     integer, allocatable :: mam_spec_to_partmc_spec(:,:)
     ! Initial q values captured on first invoke (phys_state%q not valid at inti time)
-    real(kind=dp), allocatable :: q_init(:,:,:,:)  ! (begchunk:endchunk, pcols, pver, pcnst)
     logical, allocatable :: q_init_saved(:)  ! (begchunk:endchunk)
 
 contains
@@ -354,7 +353,6 @@ end subroutine compute_partmc_emission_inputs
 
     ! Allocate storage for initial q (captured on first invoke, not here,
     ! because phys_state%q is not yet populated at inti time)
-    allocate(q_init(begchunk:endchunk, pcols, pver, pcnst))
     allocate(q_init_saved(begchunk:endchunk))
     q_init_saved(:) = .false.
 

--- a/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
+++ b/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
@@ -1336,7 +1336,7 @@ end subroutine compute_partmc_emission_inputs
           have_so4a1 = species_has_sector('so4_a1', trim(sector))
           have_so4a2 = species_has_sector('so4_a2', trim(sector))
 
-          ! Handle Hydrophobic BCPOM sectors in a4 (Accumulation) mode.
+          ! Handle hydrophobic BCPOM sectors -> MAM mode 4 (primary carbon; accumulation-sized).
           if (have_bcpom) then
              i_out = i_out + 1
              if (i_pass == 2) then
@@ -1591,16 +1591,14 @@ end subroutine compute_partmc_emission_inputs
     lchnk = state%lchnk
 
     ! Wind at 10 m, raised to the 3.41 power per Gong et al. (1997).
-    ! Same code path as aero_model.F90:2880-2887.
     do icol = 1,ncol
        u10(icol) = sqrt(state%u(icol,pver)**2 + state%v(icol,pver)**2)
        u10cubed(icol) = u10(icol) * log(10.0d0 / z0) / log(state%zm(icol,pver) / z0)
        u10cubed(icol) = u10cubed(icol)**3.41d0
     end do
 
-    ! Sea salt: bin-resolved number flux density (m^-2 s^-1) per column from
-    ! Martensson/Monahan-style polynomials in sslt_sections. Multiplied by
-    ! ocean fraction so over-land columns (ocnfrac=0) emit zero naturally.
+    ! Sea salt: bin-resolved number flux density (m^-2 s^-1) per column.
+    ! Multiplied by ocean fraction so over-land columns (ocnfrac=0) emit zero naturally.
     fi_seasalt(:ncol, :) = fluxes(cam_in%sst(:ncol), u10cubed(:ncol), ncol)
 
     do i_mode = 1, n_emit_mode
@@ -1633,22 +1631,16 @@ end subroutine compute_partmc_emission_inputs
           end if
        end if
        if ( trim(sector_modes(i_mode)%name) == 'emit_DUST' ) then
-          ! Per-column dust mass per MAM bin (same scaling as dust_model.F90
-          ! dust_emis lines 143-171), then split equally across
-          ! n_dust_subbins_per_mam_bin sub-bins (uniform mass per log(r)
-          ! within each MAM bin). Per-sub-bin number is derived from
-          ! x_mton_sub = 6/(π·ρ·D_vw_sub³) where D_vw_sub³ = 8 × <r³> with
-          ! <r³>_sub = (r_hi³ - r_lo³) / (3·ln(r_hi/r_lo)) — the volume-
-          ! weighted moment for the assumed mass-per-log(r)-uniform shape.
-          ! This conserves the MAM-bin total mass exactly (the equal-mass
-          ! split summed over sub-bins recovers M_mam_bin) while letting
-          ! PartMC sample particles across the bin's full size range.
+          ! Dust mass per MAM bin uses the same scaling as dust_model.F90's
+          ! dust_emis, then is split equally across n_dust_subbins_per_mam_bin
+          ! sub-bins (uniform mass per log(r)). Each sub-bin's mass is converted
+          ! to a number flux via its volume-weighted mean radius (the
+          ! r3_vw_subbin / x_mton math below). The equal split conserves the
+          ! MAM-bin total mass while giving PartMC finer size resolution.
           !
-          ! NOTE: aero_model.F90:2851-2868 caps total dust mass flux against
-          ! dstemislimit and rescales the per-bin distribution if the cap is
-          ! hit. That cap is not yet applied here but will not compare against
-          ! MAM's cflx unless added. Cap in theory rarely triggers in
-          ! practice, so deferred for now.
+          ! NOTE: aero_model.F90 caps total dust flux against dstemislimit and
+          ! rescales the per-bin distribution; that cap is not applied here, so
+          ! this won't match MAM cflx until it is. It rarely triggers in practice.
           do icol = 1, ncol
              soil_erod_val = soil_erodibility(icol, lchnk)
              if ( dust_emis_scheme == 2 ) soil_erod_val = 1.0d0
@@ -1657,12 +1649,10 @@ end subroutine compute_partmc_emission_inputs
              do ibin = 1, dust_nbin
                 mass_flux = sum(-cam_in%dstflx(icol, :)) * 0.73d0 / 0.87d0 &
                      * dust_emis_sclfctr(ibin) * soil_erod_val / soil_erod_fact * 1.15d0
-                ! TODO: switch from uniform-mass-per-log(r) to Kok11 brittle
-                ! fragmentation. Replace this equal split with
-                !     mass_subbin = mass_flux * w_kok11(isub_in_bin, ibin)
-                ! where w_kok11(:,:) is a precomputed weight array from integrate
-                ! Kok11's dV/dlogD over each sub-bin's edges, normalized so the
-                ! per-MAM-bin weights sum to 1.
+                ! TODO: replace this equal split with Kok11 brittle-fragmentation
+                ! weights — mass_subbin = mass_flux * w_kok11(isub_in_bin, ibin),
+                ! where w_kok11 integrates Kok11's dV/dlogD over each sub-bin,
+                ! normalized to sum to 1 per MAM bin.
                 mass_subbin = mass_flux / real(n_dust_subbins_per_mam_bin, kind=dp)
                 do isub_in_bin = 1, n_dust_subbins_per_mam_bin
                    isub = (ibin - 1) * n_dust_subbins_per_mam_bin + isub_in_bin

--- a/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
+++ b/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
@@ -644,6 +644,7 @@ end subroutine compute_partmc_emission_inputs
     use rad_constituents, only: rad_cnst_get_info, rad_cnst_get_mode_num_idx, rad_cnst_get_mam_mmr_idx
     use mo_gas_phase_chemdr, only : map2chm
     use modal_aero_data, only: ntot_amode, modename_amode, sigmag_amode, numptr_amode
+    use physconst,       only: rgas
 
     type(physics_state), intent(in) :: state
 
@@ -679,7 +680,7 @@ end subroutine compute_partmc_emission_inputs
              ! Set number concentration of the mode
              call rad_cnst_get_mode_num_idx(i_mode, num_idx)
              idx_chm = map2chm(num_idx)
-             aero_dist_init%mode(i_mode)%num_conc = state%q(icol,kk,idx_chm)
+             num_a = state%q(icol,kk,idx_chm)  ! number mixing ratio (#/kg_air)
              aero_dist_init%mode(i_mode)%vol_frac = 0.0d0
              ! Set volume fraction of the mode
              call rad_cnst_get_info(list_idx, i_mode, nspec=nspec)
@@ -701,14 +702,17 @@ end subroutine compute_partmc_emission_inputs
              else
                 aero_dist_init%mode(i_mode)%vol_frac = 1.0d0 / aero_data_n_spec(aero_data)
              end if
-             ! Calculate geometric median diameter
+             ! Calculate geometric median diameter using mixing ratios - conversions cancel
              dumfac = exp(4.5d0 * log(sigmag_amode(i_mode))**2) * const%pi / 6.0d0
-             if (aero_dist_init%mode(i_mode)%num_conc  > 0.0d0) then
-                dgnum_dry = (dryvol / (dumfac * aero_dist_init%mode(i_mode)%num_conc))**third
+             if (num_a > 0.0d0) then
+                dgnum_dry = (dryvol / (dumfac * num_a))**third
              else
                 dgnum_dry = 0.0d0
              end if
              aero_dist_init%mode(i_mode)%char_radius = dgnum_dry / 2.0d0
+             ! Convert number mixing ratio (#/kg_air) to number concentration (#/m^3)
+             aero_dist_init%mode(i_mode)%num_conc = num_a &
+                  * state%pmid(icol,kk) / (rgas * state%t(icol,kk))
           end do
           if (masterproc) then
              if (icol == 1 .and. kk == pver) then

--- a/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
+++ b/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
@@ -745,6 +745,7 @@ end subroutine compute_partmc_emission_inputs
 
   end subroutine partmc_interface_e3sm_emissions
 
+  ! Initializes aero_data from E3SM aerosol scheme.
   subroutine aero_data_init(aero_data)
 
     use rad_constituents, only: rad_cnst_get_info, rad_cnst_get_aer_props
@@ -782,7 +783,6 @@ end subroutine compute_partmc_emission_inputs
       end do
     end if
 
-    ! aero_data
     n_swbands = 1
     call ensure_string_array_size(aero_data%name, n_aero_spec)
     call ensure_integer_array_size(aero_data%mosaic_index, n_aero_spec)
@@ -792,23 +792,35 @@ end subroutine compute_partmc_emission_inputs
     call ensure_real_array_size(aero_data%molec_weight, n_aero_spec)
     call ensure_real_array_size(aero_data%kappa, n_aero_spec)
 
+    ! Set aerosol properties
     do i_spec = 1,n_aero_spec
        aero_data%name(i_spec) = mosaic_spec_name(i_spec)
        aero_data%density(i_spec) = 1800.0d0
        aero_data%kappa(i_spec) = 0.1d0
        aero_data%molec_weight(i_spec) = 18.0d0
        aero_data%num_ions(i_spec) = 0
-       if (mosaic_spec_name(i_spec) == "H2O") then
-          aero_data%i_water = i_spec
-       end if
     end do
 
+    ! Set the optical wavelength.
     aero_data%wavelengths = 550.0d0
 
+    ! Set the index of water
     call aero_data_set_water_index(aero_data)
+    ! Set MOSAIC map (not used)
     call aero_data_set_mosaic_map(aero_data)
 
     call fractal_set_spherical(aero_data%fractal)
+
+
+    ! Print results
+    if (masterproc) then
+       write(102,*) 'Contents of aero_data'
+       write(102,*) 'Name | Density | MW | kappa'
+       do i_spec = 1,n_aero_spec
+          write(102,*) trim(aero_data%name(i_spec)), aero_data%density(i_spec), &
+             aero_data%molec_weight(i_spec), aero_data%kappa(i_spec)
+       end do
+    end if
 
   end subroutine aero_data_init
 

--- a/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
+++ b/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
@@ -322,7 +322,7 @@ end subroutine compute_partmc_emission_inputs
     n_part_ideal = 250.0d0
 
     env_state_init%elapsed_time = 0d0
-    
+
     ! run_part_opt general settings
     run_part_opt%output_prefix = "./partmc_output/urban_plume"
     run_part_opt%n_repeat = 1
@@ -1028,7 +1028,7 @@ end subroutine compute_partmc_emission_inputs
       end do
       do l=1,ntot_aspectype
          write(102,*) trim(specname_amode(l)), specdens_amode(l), specmw_amode(l), spechygro(l)
-      end do 
+      end do
 
     end if
 
@@ -1048,7 +1048,7 @@ end subroutine compute_partmc_emission_inputs
     allocate(unique_kappa_array(total_mam_vars))
     allocate(unique_mw_array(total_mam_vars))
 
-    i_name = 0 
+    i_name = 0
     do m = 1,n_modes
        call rad_cnst_get_info(list_idx, m, nspec=n_spec)
        do l = 1,n_spec
@@ -1058,7 +1058,7 @@ end subroutine compute_partmc_emission_inputs
                hygro_aer = hygro)
           i_name = i_name + 1
           input_array(i_name) = aername
-          density_array(i_name) = density 
+          density_array(i_name) = density
           kappa_array(i_name) =  hygro
           mw_array(i_name) = specmw_amode(lspectype_amode(l,m))
       end do
@@ -1078,7 +1078,7 @@ end subroutine compute_partmc_emission_inputs
       unique_array(unique_count) = input_array(i)
       unique_density_array(unique_count) = density_array(i)
       unique_kappa_array(unique_count) = kappa_array(i)
-      unique_mw_array(unique_count) = mw_array(i)     
+      unique_mw_array(unique_count) = mw_array(i)
     end if
   end do
 
@@ -1107,7 +1107,7 @@ end subroutine compute_partmc_emission_inputs
        aero_data%name(i_spec) = trim(unique_array(i_spec))
        aero_data%density(i_spec) = unique_density_array(i_spec)
        aero_data%kappa(i_spec) = unique_kappa_array(i_spec)
-       aero_data%molec_weight(i_spec) = unique_mw_array(i_spec) 
+       aero_data%molec_weight(i_spec) = unique_mw_array(i_spec)
 
        ! Option 2
 !       aero_data%name(i_spec) = specname_amode(i_spec)
@@ -1137,13 +1137,13 @@ end subroutine compute_partmc_emission_inputs
        do l = 1,n_spec
           call rad_cnst_get_aer_props(list_idx, m, l, aername = aername)
           ! Find the index
-          mam_spec_to_partmc_spec(m,l) = aero_data_spec_by_name(aero_data, aername) 
+          mam_spec_to_partmc_spec(m,l) = aero_data_spec_by_name(aero_data, aername)
       end do
       if (masterproc) then
          write(102,*) mam_spec_to_partmc_spec(m,:n_spec)
       end if
     end do
-    
+
     ! Print results
     if (masterproc) then
        write(102,*) 'Contents of aero_data'

--- a/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
+++ b/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
@@ -339,6 +339,8 @@ end subroutine compute_partmc_emission_inputs
     type(aero_dist_t) :: aero_dist_init
     character(len=SPEC_LINE_MAX_VAR_LEN) :: weight_class_name
 
+    integer :: naero, n_modes
+
     ! Uncomment for processor information for debugging
     !call mpi_comm_rank(MPI_COMM_WORLD, rank, ierr)
     !print*, 'MPI rank: ', rank, 'chunk start: ', begchunk, 'chunk end:', endchunk
@@ -373,13 +375,13 @@ end subroutine compute_partmc_emission_inputs
     call gas_state_set_size(gas_state, n_gas_species)
 
     do i = 1,n_gas_species
-       gas_data%name(i) = solsym(gas_species_idx(i))
+       gas_data%name(i) = solsym(map2chm(gas_species_idx(i)))
     end do
 
     if (masterproc) then
-       write(*,*) 'PartMC gas_data names'
+       write(102,*) 'PartMC gas_data names'
        do i = 1,gas_data_n_spec(gas_data)
-          write(*,*) trim(gas_data%name(i))
+          write(102,*) trim(gas_data%name(i))
        end do
     end if
 
@@ -679,14 +681,19 @@ end subroutine compute_partmc_emission_inputs
              ! Set number concentration of the mode
              call rad_cnst_get_mode_num_idx(i_mode, num_idx)
              idx_chm = map2chm(num_idx)
-             num_a = state%q(icol,kk,idx_chm)  ! number mixing ratio (#/kg_air)
+             if (masterproc) then
+                if (kk == pver .and. icol == 1) then
+                   write(102,*) "Initial number mixing ratio for mode ", i_mode, " is ", state%q(icol,kk,idx_chm), idx_chm, state%q(icol,kk,num_idx),num_idx
+                end if
+             end if
+             num_a = state%q(icol,kk,num_idx)  ! number mixing ratio (#/kg_air)
              aero_dist_init%mode(i_mode)%vol_frac = 0.0d0
              ! Set volume fraction of the mode
              call rad_cnst_get_info(list_idx, i_mode, nspec=nspec)
              dryvol = 0.d0
              do i_spec = 1,nspec
                 call rad_cnst_get_mam_mmr_idx(i_mode, i_spec, spec_idx)
-                idx_chm = map2chm(spec_idx)
+                idx_chm = spec_idx !map2chm(spec_idx)
                 pmc_aero_idx = mam_spec_to_partmc_spec(i_mode, i_spec)
                 ! Convert from mass mixing ratio to volume fraction using density
                 aero_dist_init%mode(i_mode)%vol_frac(pmc_aero_idx) = &
@@ -701,7 +708,7 @@ end subroutine compute_partmc_emission_inputs
              else
                 aero_dist_init%mode(i_mode)%vol_frac = 1.0d0 / aero_data_n_spec(aero_data)
              end if
-             ! Calculate geometric median diameter using mixing ratios - conversions cancel
+             ! Calculate geometric mean diameter using mixing ratios - conversions cancel
              dumfac = exp(4.5d0 * log(sigmag_amode(i_mode))**2) * const%pi / 6.0d0
              if (num_a > 0.0d0) then
                 dgnum_dry = (dryvol / (dumfac * num_a))**third

--- a/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
+++ b/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
@@ -69,8 +69,18 @@ module mo_partmc_interface
        integer :: n_num            ! Number of species in the number flux.
        character(len=16), allocatable :: num_species(:)   ! num_aN
        character(len=32), allocatable :: num_sec_var(:)   ! sector var in num file
+       ! Sampled-mode metadata for natural sources (SEASALT, DUST). For
+       ! anthropogenic modes is_sampled stays .false. and these fields are unused.
+       logical :: is_sampled = .false.
+       integer :: n_samples  = 0                       ! number of bins
+       real(kind=dp), allocatable :: sample_radius(:)  ! n_samples+1 bin edge radii (m)
+       integer :: sample_pmc_idx = 0                   ! single composition species index
+                                                       ! (sampled modes have one vol_frac=1 species)
     end type sector_mode_t
     type(sector_mode_t), allocatable :: sector_modes(:)
+    ! Max bins across sampled modes — used to size the per-step
+    ! sample_num_conc buffer in partmc_mam_invoke. Set at catalog build.
+    integer :: max_n_samples = 0
     character, allocatable :: buffer(:)
     integer :: buffer_size, max_buffer_size
     integer :: position
@@ -521,14 +531,22 @@ end subroutine compute_partmc_emission_inputs
   end subroutine partmc_mam_inti
 
   ! Solves a time step dt of PartMC.
-  subroutine partmc_mam_invoke(state, cflx, dt)
+  subroutine partmc_mam_invoke(state, cam_in, cflx, dt)
     use physics_types,    only : physics_state
+    use camsrfexch,       only : cam_in_t
     use cam_history,       only : outfld
     use constituents,     only: pcnst
     use mo_chem_utls,        only : get_spc_ndx
     use physconst,    only: spec_class_aerosol, spec_class_gas
+    use ppgrid,           only : pver
 
     type(physics_state), intent(inout):: state
+    ! cam_in carries sst, ocnfrac, dstflx for the natural-source pathway
+    ! (sea salt, dust). Anthropogenic pathway uses cflx as before.
+    ! TODO: once the natural-source field set is settled, decide whether to
+    ! narrow this to specific args (sst, ocnfrac, dstflx, ...) for an
+    ! explicit contract.
+    type(cam_in_t),      intent(in) :: cam_in
     real(kind=dp),       intent(in) :: cflx(pcols,pcnst)              ! constituent surface flux (kg/m^2/s)
     real(kind=dp),            intent(in)    :: dt              ! time step
 
@@ -547,6 +565,9 @@ end subroutine compute_partmc_emission_inputs
     real(kind=dp), allocatable :: sigma_emode(:)
     real(kind=dp), allocatable :: num_fluxes_sec(:,:)
     real(kind=dp), allocatable :: vol_frac_sec(:,:,:)
+    ! Natural-source per-step buffers (sampled-mode pathway)
+    real(kind=dp), allocatable :: u10cubed(:)              ! (pcols)
+    real(kind=dp), allocatable :: sample_num_conc(:,:,:)   ! (pcols, n_emit_mode, max_n_samples)
 
     integer ::  n_samp, n_coag, i_time, n_time, n_emit
     integer :: i_mode
@@ -596,6 +617,14 @@ end subroutine compute_partmc_emission_inputs
        allocate(vol_frac_sec(pcols, n_emit_mode, aero_data_n_spec(aero_data)))
        call compute_partmc_emission_inputs_sector(lchnk, ncol, &
             geom_mean_diameter_sec, sigma_emode, num_fluxes_sec, vol_frac_sec)
+       ! Natural-source pseudo-modes (SEASALT, DUST). Stub fills u10cubed
+       ! and zeros sample_num_conc — real bin-resolved emission goes here.
+       if ( max_n_samples > 0 ) then
+          allocate(u10cubed(pcols))
+          allocate(sample_num_conc(pcols, n_emit_mode, max_n_samples))
+          call compute_partmc_natural_emission_inputs(state, cam_in, ncol, &
+               u10cubed, sample_num_conc)
+       end if
     else
        geom_mean_diameter(:,:) = 0d0
        num_fluxes(:,:) = 0d0
@@ -652,9 +681,18 @@ end subroutine compute_partmc_emission_inputs
           n_emit = 0
           ! Set the PartMC data structure for aerosol emissions
           if (use_sector_emissions) then
-             call partmc_interface_e3sm_emissions_sector(emissions, &
-                  geom_mean_diameter_sec(icol,:), sigma_emode, &
-                  num_fluxes_sec(icol,:), vol_frac_sec(icol,:,:))
+             ! TODO: we can refactor this when we are happy with the mixing of modal
+             ! vs binned emissions.
+             if ( allocated(sample_num_conc) ) then
+                call partmc_interface_e3sm_emissions_sector(emissions, &
+                     geom_mean_diameter_sec(icol,:), sigma_emode, &
+                     num_fluxes_sec(icol,:), vol_frac_sec(icol,:,:), &
+                     sample_num_conc(icol,:,:))
+             else
+                call partmc_interface_e3sm_emissions_sector(emissions, &
+                     geom_mean_diameter_sec(icol,:), sigma_emode, &
+                     num_fluxes_sec(icol,:), vol_frac_sec(icol,:,:))
+             end if
           else
              call partmc_interface_e3sm_emissions(state, emissions, &
                   geom_mean_diameter(icol,:), sigma_mam, num_fluxes(icol,:), volume_fractions(icol,:,:))
@@ -728,6 +766,8 @@ end subroutine compute_partmc_emission_inputs
 
     if (use_sector_emissions) then
        deallocate(geom_mean_diameter_sec, sigma_emode, num_fluxes_sec, vol_frac_sec)
+       if ( allocated(u10cubed) )        deallocate(u10cubed)
+       if ( allocated(sample_num_conc) ) deallocate(sample_num_conc)
     end if
 
   end subroutine partmc_mam_invoke
@@ -1175,17 +1215,83 @@ end subroutine compute_partmc_emission_inputs
 
   end function species_has_sector
 
+  ! Populates a sector_mode_t entry for the SEASALT pseudo-mode.
+  !
+  ! TODO: Currently we are just sampling a single SEASALT mode but we may
+  ! want to add organics later, either as another external mode or interally
+  ! mixed with the sea salt.
+  subroutine build_seasalt_sector_mode(sm)
+    use sslt_sections,    only : nsections, rdry
+    use modal_aero_data,  only : sigmag_amode
+
+    type(sector_mode_t), intent(inout) :: sm
+    integer :: i
+
+    sm%name = 'emit_SEASALT'
+    sm%sector = 'OCEAN'
+    sm%parent_mam_mode = 0
+    sm%sigma_g = sigmag_amode(1) ! unused for sampled mode
+    sm%n_mass = 0 ! unused for sampled mode
+    sm%n_num  = 0 ! unused for sampled mode
+
+    sm%is_sampled = .true.
+    sm%n_samples = nsections
+    ! Any ncl constituent will work here.
+    sm%sample_pmc_idx = pmc_idx_for_constituent('ncl_a1')
+
+    ! The bin center radii in rdry are log-spaced; sample_radius
+    ! holds n_samples+1 bin edges constructed by geometric midpoint of
+    ! consecutive centers, with the first/last edges extrapolated using
+    ! the same log-ratio so PartMC's sampled-mode implementation can be used
+    ! without any modification.
+    allocate(sm%sample_radius(nsections + 1))
+    do i = 2,nsections
+       sm%sample_radius(i) = sqrt(rdry(i-1) * rdry(i))
+    end do
+    ! Extrapolate first and last edges using the same log-ratio as the adjacent bins.
+    sm%sample_radius(1) = rdry(1) * sqrt(rdry(1) / rdry(2))
+    sm%sample_radius(nsections+1) = rdry(nsections) * sqrt(rdry(nsections) / rdry(nsections-1))
+
+  end subroutine build_seasalt_sector_mode
+
+  ! Populates a sector_mode_t entry for the DUST pseudo-mode.
+  subroutine build_dust_sector_mode(sm)
+    use dust_model,       only : dust_nbin, dust_dmt_grd
+    use modal_aero_data,  only : sigmag_amode
+
+    type(sector_mode_t), intent(inout) :: sm
+
+    sm%name = 'emit_DUST'
+    sm%sector = 'LAND'
+    sm%parent_mam_mode = 0
+    sm%sigma_g = sigmag_amode(3) ! unused for sampled mode
+    sm%n_mass = 0 ! unused for sampled mode
+    sm%n_num  = 0 ! unused for sampled mode
+
+    sm%is_sampled = .true.
+    sm%n_samples  = dust_nbin
+    ! Any dst constituent will work here.
+    sm%sample_pmc_idx = pmc_idx_for_constituent('dst_a1')
+
+    ! The dust grid dust_dmt_grd already holds dust_nbin+1 bin edge diameters,
+    ! so sample_radius is just dust_dmt_grd / 2.
+    allocate(sm%sample_radius(dust_nbin + 1))
+    sm%sample_radius(:) = dust_dmt_grd(:) / 2.0d0
+
+  end subroutine build_dust_sector_mode
+
   ! Walks the canonical CMIP6 anthropogenic sector list and builds one
   ! sector_modes entry per (MAM-group, sector) pair that is actually present
   ! in the inventory. Sets module-level n_emit_mode to the discovered count.
   !
-  ! MAM-groups handled (MAM4 + CMIP6):
+  ! Example MAM-groups handled (MAM4 + CMIP6):
   !   * BCPOM  (parent mode 4) — bc_a4 + pom_a4 + num_a4
   !   * SO4a1  (parent mode 1) — so4_a1 + num_a1
   !   * SO4a2  (parent mode 2) — so4_a2 + num_a2
   !
   ! The MAM split between so4_a1/so4_a2 (and the corresponding number)
-  ! is inherited as-is.
+  ! is inherited as-is. SEASALT and DUST natural modes are appended
+  ! to the catalog via build_seasalt_sector_mode / build_dust_sector_mode.
   subroutine partmc_build_sector_catalog()
     use modal_aero_data, only : sigmag_amode
 
@@ -1283,32 +1389,30 @@ end subroutine compute_partmc_emission_inputs
           end if
        end do
 
-       ! Natural-source scaffolding: register one pseudo-mode per natural source
-       ! so aero_data knows about the source/weight-class names. Real bin-resolved
-       ! fluxes from seasalt_emis / dust_emis get wired in later.
+       ! Natural-sources: register modes for natural source so aero_data knows about
+       ! the source/weight-class names. Populate mode sample_radius edges here while
+       ! per-step sample_num_conc is computed by compute_partmc_natural_emission_inputs.
        i_out = i_out + 1
        if (i_pass == 2) then
-          sector_modes(i_out)%name = 'emit_SEASALT'
-          sector_modes(i_out)%sector = 'OCEAN'
-          sector_modes(i_out)%parent_mam_mode = 0
-          sector_modes(i_out)%sigma_g = sigmag_amode(1)  ! placeholder until sampled-mode wiring
-          sector_modes(i_out)%n_mass = 0
-          sector_modes(i_out)%n_num  = 0
+          call build_seasalt_sector_mode(sector_modes(i_out))
        end if
 
        i_out = i_out + 1
        if (i_pass == 2) then
-          sector_modes(i_out)%name = 'emit_DUST'
-          sector_modes(i_out)%sector = 'LAND'
-          sector_modes(i_out)%parent_mam_mode = 0
-          sector_modes(i_out)%sigma_g = sigmag_amode(3)  ! placeholder until sampled-mode wiring
-          sector_modes(i_out)%n_mass = 0
-          sector_modes(i_out)%n_num  = 0
+          call build_dust_sector_mode(sector_modes(i_out))
        end if
 
        if (i_pass == 1) then
           n_emit_mode = i_out
           allocate(sector_modes(n_emit_mode))
+       end if
+    end do
+
+    ! Determine max_n_samples for the sampled mode array to be properly sized
+    max_n_samples = 0
+    do i_out = 1, n_emit_mode
+       if (sector_modes(i_out)%n_samples > max_n_samples) then
+          max_n_samples = sector_modes(i_out)%n_samples
        end if
     end do
 
@@ -1413,11 +1517,102 @@ end subroutine compute_partmc_emission_inputs
 
   end subroutine compute_partmc_emission_inputs_sector
 
-  ! Sector-resolved version of partmc_interface_e3sm_emissions.
-  subroutine partmc_interface_e3sm_emissions_sector(emissions, geom_mean_diam, &
-       sigma_emode, num_fluxes, vol_frac)
+  ! Stub: per-step inputs for the natural-source pseudo-modes (SEASALT, DUST).
+  !
+  ! Real implementation (to fill in):
+  !   * Seasalt: fi(:ncol,:nsections) = sslt_sections::fluxes(cam_in%sst, u10cubed, ncol)
+  !              sample_num_conc(icol, seasalt_mode_idx, ibin) =
+  !                fi(icol, ibin) * cam_in%ocnfrac(icol) * seasalt_emis_scale
+  !   * Dust:    derive per-bin number from cam_in%dstflx + soil_erodibility +
+  !              dust_emis_sclfctr + dust_dmt_vwr (mass→number conversion).
+  subroutine compute_partmc_natural_emission_inputs(state, cam_in, ncol, &
+       u10cubed, sample_num_conc)
+    use physics_types, only : physics_state
+    use camsrfexch,    only : cam_in_t
+    use ppgrid,        only : pver
+    use sslt_sections, only : nsections, fluxes
+    use aero_model,    only : seasalt_emis_scale
 
-    ! Emissions data structure to pass to PartMC.
+    ! Current physics state.
+    type(physics_state), intent(in)  :: state
+    ! cam_in: passed to provide access to surface variables.
+    type(cam_in_t), intent(in)  :: cam_in
+    ! Number of columns in chunk.
+    integer, intent(in)  :: ncol
+    ! Wind at 10 m raised to the 3.41 power, indexed by column.
+    real(kind=dp), intent(out) :: u10cubed(:)
+    ! Sampled per-bin number flux indexed by (column, sector_mode, bin).
+    ! Only sea salt and dust modes will have non-zero entries here and
+    ! log-normal modes will ignore this array.
+    real(kind=dp), intent(out) :: sample_num_conc(:,:,:)
+
+    real(kind=dp), parameter :: z0 = 1.0d-4 ! ocean roughness length (m); matches aero_model.F90
+    real(kind=dp) :: u10(pcols)
+    real(kind=dp) :: fi_seasalt(pcols, nsections)
+    integer :: icol, ibin, i_mode
+
+    sample_num_conc(:,:,:) = 0.0d0
+    u10cubed(:) = 0.0d0
+
+    ! Wind at 10 m, raised to the 3.41 power per Gong et al. (1997).
+    ! Same code path as aero_model.F90:2880-2887.
+    do icol = 1,ncol
+       u10(icol) = sqrt(state%u(icol,pver)**2 + state%v(icol,pver)**2)
+       u10cubed(icol) = u10(icol) * log(10.0d0 / z0) / log(state%zm(icol,pver) / z0)
+       u10cubed(icol) = u10cubed(icol)**3.41d0
+    end do
+
+    ! Sea salt: bin-resolved number flux density (m^-2 s^-1) per column from
+    ! Martensson/Monahan-style polynomials in sslt_sections. Multiplied by
+    ! ocean fraction so over-land columns (ocnfrac=0) emit zero naturally.
+    fi_seasalt(:ncol, :) = fluxes(cam_in%sst(:ncol), u10cubed(:ncol), ncol)
+
+    do i_mode = 1, n_emit_mode
+       if ( .not. sector_modes(i_mode)%is_sampled ) cycle
+       if ( trim(sector_modes(i_mode)%name) == 'emit_SEASALT' ) then
+          do icol = 1, ncol
+             do ibin = 1, nsections
+                sample_num_conc(icol, i_mode, ibin) = &
+                     max(0.0d0, fi_seasalt(icol, ibin)) &
+                     * cam_in%ocnfrac(icol) * seasalt_emis_scale
+             end do
+          end do
+
+          if ( masterproc ) then
+             write(102,*) '-----------------------------------------'
+             write(102,*) 'Sea salt sample_num_conc (i_mode=', i_mode, ')'
+             write(102,*) 'seasalt_emis_scale (from aero_model namelist) = ', seasalt_emis_scale
+             write(102,*) 'icol | sst | ocnfrac | u10cubed | total num flux (m^-2 s^-1)'
+             do icol = 1, ncol
+                write(102,*) icol, cam_in%sst(icol), cam_in%ocnfrac(icol), &
+                     u10cubed(icol), sum(sample_num_conc(icol, i_mode, 1:nsections))
+             end do
+             write(102,*) 'Per-bin breakdown (icol = 1):'
+             write(102,*) 'ibin | radius (m) | num_conc (m^-2 s^-1)'
+             do ibin = 1, nsections
+                write(102,*) ibin, sector_modes(i_mode)%sample_radius(ibin), &
+                     sample_num_conc(1, i_mode, ibin)
+             end do
+             write(102,*) '-----------------------------------------'
+          end if
+       end if
+       ! TODO: 'emit_DUST' branch — derive per-bin number from cam_in%dstflx,
+       ! soil_erodibility, dust_emis_sclfctr, and dust_dmt_vwr.
+
+    end do
+
+  end subroutine compute_partmc_natural_emission_inputs
+
+  ! Sector-resolved version of partmc_interface_e3sm_emissions. Branches per
+  ! mode: anthropogenic modes get AERO_MODE_TYPE_LOG_NORMAL with the usual
+  ! (char_radius, sigma, num_conc, vol_frac); natural sampled modes
+  ! (sector_modes(i)%is_sampled == .true.) get AERO_MODE_TYPE_SAMPLED with
+  ! per-bin (sample_radius, sample_num_conc) and a single-species vol_frac.
+  ! Returns the emissions data structure to be passed to PartMC for the current step.
+  subroutine partmc_interface_e3sm_emissions_sector(emissions, geom_mean_diam, &
+       sigma_emode, num_fluxes, vol_frac, sample_num_conc)
+
+    ! Emissions data structure to pass to PartMC for sampling.
     type(aero_dist_t), intent(inout) :: emissions
     ! Geometric mean diameter of each sector mode. Not necesarily the same
     ! as the parent MAM mode diameter.
@@ -1430,8 +1625,11 @@ end subroutine compute_partmc_emission_inputs
     ! PartMC species index, not per-mode species index so no per-mode species
     ! mapping needed.
     real(kind=dp), intent(in) :: vol_frac(:,:)       ! (n_emit_mode, n_aero_spec)
+    ! Per-bin number flux for sampled modes; ignored for log-normal modes.
+    ! Currently may be unallocated when no sampled modes are present.
+    real(kind=dp), intent(in), optional :: sample_num_conc(:,:)  ! (n_emit_mode, max_n_samples)
 
-    integer :: i_mode, n_aero_spec
+    integer :: i_mode, n_aero_spec, n_smp, pmc_idx
     character(len=AERO_MODE_NAME_LEN) :: mode_name
     character(len=SPEC_LINE_MAX_VAR_LEN) :: weight_class_name
 
@@ -1443,23 +1641,48 @@ end subroutine compute_partmc_emission_inputs
     do i_mode = 1, n_emit_mode
        mode_name = sector_modes(i_mode)%name
        emissions%mode(i_mode)%name = mode_name
-       emissions%mode(i_mode)%type = AERO_MODE_TYPE_LOG_NORMAL
        emissions%mode(i_mode)%source = aero_data_source_by_name(aero_data, mode_name)
        weight_class_name = mode_name
        emissions%mode(i_mode)%weight_class = &
             aero_data_weight_class_by_name(aero_data, weight_class_name)
-       emissions%mode(i_mode)%char_radius = geom_mean_diam(i_mode) / 2.0d0
-       emissions%mode(i_mode)%log10_std_dev_radius = log10(sigma_emode(i_mode))
-       emissions%mode(i_mode)%num_conc = num_fluxes(i_mode)
 
        allocate(emissions%mode(i_mode)%vol_frac(n_aero_spec))
        allocate(emissions%mode(i_mode)%vol_frac_std(n_aero_spec))
-       emissions%mode(i_mode)%vol_frac(:) = vol_frac(i_mode, :)
-
-       ! Set these to zero.
        emissions%mode(i_mode)%vol_frac_std(:) = 0.0d0
-       emissions%mode(i_mode)%sample_radius = [ real(kind=dp) :: ]
-       emissions%mode(i_mode)%sample_num_conc = [ real(kind=dp) :: ]
+
+       if ( sector_modes(i_mode)%is_sampled ) then
+          ! Sampled-mode (binned) pathway for natural sources.
+          emissions%mode(i_mode)%type = AERO_MODE_TYPE_SAMPLED
+          ! char_radius and log10_std_dev_radius unused by sampled mode
+          emissions%mode(i_mode)%char_radius = 0.0d0
+          emissions%mode(i_mode)%log10_std_dev_radius = log10(sigma_emode(i_mode))
+
+          n_smp = sector_modes(i_mode)%n_samples
+          emissions%mode(i_mode)%sample_radius   = sector_modes(i_mode)%sample_radius(:)
+          if ( present(sample_num_conc) ) then
+             emissions%mode(i_mode)%sample_num_conc = sample_num_conc(i_mode, 1:n_smp)
+          else
+             emissions%mode(i_mode)%sample_num_conc = spread(0.0d0, 1, n_smp)
+          end if
+          emissions%mode(i_mode)%num_conc = sum(emissions%mode(i_mode)%sample_num_conc)
+
+          ! Single-species composition: put all volume fraction into
+          ! sample_pmc_idx (e.g. ncl_a1 for SEASALT, dst_a1 for DUST).
+          ! TODO: If we add organics to be internally mixed with sea salt,
+          ! we will need to split the vol_frac between sea salt and organics.
+          emissions%mode(i_mode)%vol_frac(:) = 0.0d0
+          pmc_idx = sector_modes(i_mode)%sample_pmc_idx
+          if (pmc_idx > 0) emissions%mode(i_mode)%vol_frac(pmc_idx) = 1.0d0
+       else
+          ! Anthropogenic log-normal pathway.
+          emissions%mode(i_mode)%type = AERO_MODE_TYPE_LOG_NORMAL
+          emissions%mode(i_mode)%char_radius          = geom_mean_diam(i_mode) / 2.0d0
+          emissions%mode(i_mode)%log10_std_dev_radius = log10(sigma_emode(i_mode))
+          emissions%mode(i_mode)%num_conc             = num_fluxes(i_mode)
+          emissions%mode(i_mode)%vol_frac(:)          = vol_frac(i_mode, :)
+          emissions%mode(i_mode)%sample_radius        = [ real(kind=dp) :: ]
+          emissions%mode(i_mode)%sample_num_conc      = [ real(kind=dp) :: ]
+       end if
     end do
 
   end subroutine partmc_interface_e3sm_emissions_sector

--- a/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
+++ b/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
@@ -242,14 +242,16 @@ subroutine compute_partmc_emission_inputs(cflx, ncol, geom_mean_diameter, std_ma
 
 end subroutine compute_partmc_emission_inputs
 
-  subroutine spec_file_read_run_part_eam(run_part_opt, aero_data, &
+  subroutine spec_file_read_run_part_eam(run_part_opt, &
        env_state_init, &
        n_part, rand_init)
 
+    use rad_constituents, only: rad_cnst_get_info, rad_cnst_get_aer_props
+    use modal_aero_data, only: &
+        lspectype_amode
+
     !> Monte Carlo options.
     type(run_part_opt_t), intent(inout) :: run_part_opt
-    !> Aerosol data.
-    type(aero_data_t), intent(inout) :: aero_data
     !> Initial environmental state.
     type(env_state_t), intent(inout) :: env_state_init
     !> Ideal number of computational particles.
@@ -272,7 +274,9 @@ end subroutine compute_partmc_emission_inputs
     integer, parameter :: n_gas_spec = 77
     integer :: n_swbands
     integer :: i_spec, i_mode
-
+    integer :: m, l
+    integer :: n_spec
+    real(kind=dp) :: density, hygro
     character(AERO_NAME_LEN), parameter, dimension(n_aero_spec) :: &
          mosaic_spec_name = [ &
          "SO4   ", "NO3   ", "Cl    ", "NH4   ", "MSA   ", "ARO1  ", &
@@ -280,38 +284,12 @@ end subroutine compute_partmc_emission_inputs
          "LIM2  ", "CO3   ", "Na    ", "Ca    ", "OIN   ", "OC    ", &
          "BC    ", "H2O   "]
     character(len=SPEC_LINE_MAX_VAR_LEN) :: weight_class_name
+    character(len=20):: aername
 
     n_part = 50
 
     env_state_init%elapsed_time = 0d0
-
-    ! aero_data
-    n_swbands = 1
-    call ensure_string_array_size(aero_data%name, n_aero_spec)
-    call ensure_integer_array_size(aero_data%mosaic_index, n_aero_spec)
-    call ensure_real_array_size(aero_data%wavelengths, n_swbands)
-    call ensure_real_array_size(aero_data%density, n_aero_spec)
-    call ensure_integer_array_size(aero_data%num_ions, n_aero_spec)
-    call ensure_real_array_size(aero_data%molec_weight, n_aero_spec)
-    call ensure_real_array_size(aero_data%kappa, n_aero_spec)
-
-    do i_spec = 1,n_aero_spec
-       aero_data%name(i_spec) = mosaic_spec_name(i_spec)
-       aero_data%density(i_spec) = 1800.0d0
-       aero_data%kappa(i_spec) = 0.1d0
-       aero_data%molec_weight(i_spec) = 18.0d0
-       aero_data%num_ions(i_spec) = 0
-       if (mosaic_spec_name(i_spec) == "H2O") then
-          aero_data%i_water = i_spec
-       end if
-    end do
-    aero_data%wavelengths = 550.0d0
-
-    call aero_data_set_water_index(aero_data)
-    call aero_data_set_mosaic_map(aero_data)
-
-    call fractal_set_spherical(aero_data%fractal)
-
+    
     ! run_part_opt general settings
     run_part_opt%output_prefix = "./partmc_output/urban_plume"
     run_part_opt%n_repeat = 1
@@ -422,7 +400,10 @@ end subroutine compute_partmc_emission_inputs
      end do
   end if
 
-  call spec_file_read_run_part_eam(run_part_opt, aero_data, &
+  ! Initialization of aerosol data
+  call aero_data_init(aero_data)
+
+  call spec_file_read_run_part_eam(run_part_opt, &
        env_state_init, &
        n_part, rand_init)
 
@@ -763,5 +744,72 @@ end subroutine compute_partmc_emission_inputs
     end do
 
   end subroutine partmc_interface_e3sm_emissions
+
+  subroutine aero_data_init(aero_data)
+
+    use rad_constituents, only: rad_cnst_get_info, rad_cnst_get_aer_props
+    use modal_aero_data, only: &
+        lspectype_amode
+
+    !> Aerosol data.
+    type(aero_data_t), intent(inout) :: aero_data
+
+    integer, parameter :: n_aero_spec = 20
+    integer :: n_swbands
+    integer :: i_spec, i_mode
+    integer :: m, l
+    integer :: n_spec
+    real(kind=dp) :: density, hygro
+    character(AERO_NAME_LEN), parameter, dimension(n_aero_spec) :: &
+         mosaic_spec_name = [ &
+         "SO4   ", "NO3   ", "Cl    ", "NH4   ", "MSA   ", "ARO1  ", &
+         "ARO2  ", "ALK1  ", "OLE1  ", "API1  ", "API2  ", "LIM1  ", &
+         "LIM2  ", "CO3   ", "Na    ", "Ca    ", "OIN   ", "OC    ", &
+         "BC    ", "H2O   "]
+    character(len=20):: aername
+
+    if (masterproc) then
+      do m = 1,5 ! nmodes
+         ! Properties of modal species
+         call rad_cnst_get_info(0, m, nspec=n_spec)
+         do l = 1, n_spec
+            call rad_cnst_get_aer_props(0, m, l, &
+               aername = aername, &
+               density_aer = density, &
+               hygro_aer   = hygro)
+           write(102,*) m,l, trim(aername),density, hygro, lspectype_amode(l,m)
+         end do
+      end do
+    end if
+
+    ! aero_data
+    n_swbands = 1
+    call ensure_string_array_size(aero_data%name, n_aero_spec)
+    call ensure_integer_array_size(aero_data%mosaic_index, n_aero_spec)
+    call ensure_real_array_size(aero_data%wavelengths, n_swbands)
+    call ensure_real_array_size(aero_data%density, n_aero_spec)
+    call ensure_integer_array_size(aero_data%num_ions, n_aero_spec)
+    call ensure_real_array_size(aero_data%molec_weight, n_aero_spec)
+    call ensure_real_array_size(aero_data%kappa, n_aero_spec)
+
+    do i_spec = 1,n_aero_spec
+       aero_data%name(i_spec) = mosaic_spec_name(i_spec)
+       aero_data%density(i_spec) = 1800.0d0
+       aero_data%kappa(i_spec) = 0.1d0
+       aero_data%molec_weight(i_spec) = 18.0d0
+       aero_data%num_ions(i_spec) = 0
+       if (mosaic_spec_name(i_spec) == "H2O") then
+          aero_data%i_water = i_spec
+       end if
+    end do
+
+    aero_data%wavelengths = 550.0d0
+
+    call aero_data_set_water_index(aero_data)
+    call aero_data_set_mosaic_map(aero_data)
+
+    call fractal_set_spherical(aero_data%fractal)
+
+  end subroutine aero_data_init
 
 end module mo_partmc_interface

--- a/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
+++ b/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
@@ -42,12 +42,13 @@ module mo_partmc_interface
     integer, parameter, public :: n_aero_sp_max = 25
 
     ! Toggle between two emission pathways:
-    !   .false. — original cflx pathway (5 generic emit modes per MAM mode)
+    !   .false. — original cflx pathway (5 generic emit modes)
     !   .true.  — sector-resolved pathway (one PartMC mode per (MAM mode, CMIP6 sector))
     logical, parameter, public :: use_sector_emissions = .true.
     ! Number of active PartMC emission modes. For the cflx pathway this stays 5;
     ! for the sector pathway it is overwritten at init from the discovered
-    ! catalog (typically 14 for MAM4 + CMIP6 anthropogenic inventory).
+    ! catalog: one mode per present (MAM-group, CMIP6 sector) pair plus the two
+    ! natural sampled modes (sea salt, dust).
     integer, public :: n_emit_mode = 5
     ! Canonical anthropogenic sector list (CMIP6 / AeroCom). The sector
     ! catalog only registers a (MAM-group, sector) pair if the inventory
@@ -77,10 +78,18 @@ module mo_partmc_interface
        integer :: sample_pmc_idx = 0                   ! single composition species index
                                                        ! (sampled modes have one vol_frac=1 species)
     end type sector_mode_t
+
     type(sector_mode_t), allocatable :: sector_modes(:)
     ! Max bins across sampled modes — used to size the per-step
-    ! sample_num_conc buffer in partmc_mam_invoke. Set at catalog build.
+    ! sample_num_conc buffer in partmc_mam_invoke.
     integer :: max_n_samples = 0
+    ! Number of PartMC sub-bins per MAM dust bin. MAM has 2 wide dust bins
+    ! (0.1-1 and 1-10 microns diameters); subdividing log-uniformly into K sub-bins
+    ! per MAM bin gives PartMC finer size resolution while keeping the total
+    ! mass per MAM bin equal to dust_emis output. Example: K=8 leads to
+    ! 10^(1/8) = 1.33, putting mass error from log-uniform sampling within
+    ! each sub-bin at the few-percent level.
+    integer, parameter :: n_dust_subbins_per_mam_bin = 8
     character, allocatable :: buffer(:)
     integer :: buffer_size, max_buffer_size
     integer :: position
@@ -406,8 +415,8 @@ end subroutine compute_partmc_emission_inputs
     allocate(q_init_saved(begchunk:endchunk))
     q_init_saved(:) = .false.
 
-    ! Get number of actual (active) gas species.
-    ! gas_pncst is "gas" species which apparently is not just gases.
+    ! Count and collect the gas-phase constituents out of the
+    ! full constituent list; gas_data/gas_state are sized to this count.
     n_gas_species = 0
     do i = 1,pcnst
        if (species_class(i) == spec_class_gas) then
@@ -417,7 +426,7 @@ end subroutine compute_partmc_emission_inputs
     end do
 
     if (masterproc) then
-       print*, 'number of active (?) gas species', n_gas_species
+       write(102,*) 'Number of active gas species:', n_gas_species
     end if
 
     call ensure_string_array_size(gas_data%name, n_gas_species)
@@ -542,13 +551,12 @@ end subroutine compute_partmc_emission_inputs
 
     type(physics_state), intent(inout):: state
     ! cam_in carries sst, ocnfrac, dstflx for the natural-source pathway
-    ! (sea salt, dust). Anthropogenic pathway uses cflx as before.
+    ! (sea salt, dust). cflx carries the emissions for MAM modes (but not sectors).
     ! TODO: once the natural-source field set is settled, decide whether to
-    ! narrow this to specific args (sst, ocnfrac, dstflx, ...) for an
-    ! explicit contract.
+    ! narrow this to specific arguments (sst, ocnfrac, dstflx, ...).
     type(cam_in_t),      intent(in) :: cam_in
-    real(kind=dp),       intent(in) :: cflx(pcols,pcnst)              ! constituent surface flux (kg/m^2/s)
-    real(kind=dp),            intent(in)    :: dt              ! time step
+    real(kind=dp),       intent(in) :: cflx(pcols,pcnst)  ! constituent surface flux (kg/m^2/s)
+    real(kind=dp),            intent(in)    :: dt         ! time step
 
     integer :: i, icol, kk, lchnk, ncol
     real(kind=dp) ::  aero_particle_mass_out(pcols, pver,  n_part_max,n_aero_sp_max)
@@ -617,8 +625,8 @@ end subroutine compute_partmc_emission_inputs
        allocate(vol_frac_sec(pcols, n_emit_mode, aero_data_n_spec(aero_data)))
        call compute_partmc_emission_inputs_sector(lchnk, ncol, &
             geom_mean_diameter_sec, sigma_emode, num_fluxes_sec, vol_frac_sec)
-       ! Natural-source pseudo-modes (SEASALT, DUST). Stub fills u10cubed
-       ! and zeros sample_num_conc — real bin-resolved emission goes here.
+       ! Natural-source pseudo-modes (SEASALT, DUST): fills u10cubed and the
+       ! bin-resolved sample_num_conc number fluxes.
        if ( max_n_samples > 0 ) then
           allocate(u10cubed(pcols))
           allocate(sample_num_conc(pcols, n_emit_mode, max_n_samples))
@@ -1254,12 +1262,17 @@ end subroutine compute_partmc_emission_inputs
 
   end subroutine build_seasalt_sector_mode
 
-  ! Populates a sector_mode_t entry for the DUST pseudo-mode.
+  ! Populates a sector_mode_t entry for the DUST pseudo-mode. Subdivides
+  ! each of MAM's dust_nbin wide bins into K = n_dust_subbins_per_mam_bin
+  ! log-spaced sub-bins. The full sample_radius edge array spans all MAM
+  ! bins and shares the inter-MAM-bin edge between adjacent sub-bins.
   subroutine build_dust_sector_mode(sm)
     use dust_model,       only : dust_nbin, dust_dmt_grd
     use modal_aero_data,  only : sigmag_amode
 
     type(sector_mode_t), intent(inout) :: sm
+    integer :: m, k, isub
+    real(kind=dp) :: r_lo, r_hi, log_ratio
 
     sm%name = 'emit_DUST'
     sm%sector = 'LAND'
@@ -1269,14 +1282,26 @@ end subroutine compute_partmc_emission_inputs
     sm%n_num  = 0 ! unused for sampled mode
 
     sm%is_sampled = .true.
-    sm%n_samples  = dust_nbin
+    sm%n_samples  = dust_nbin * n_dust_subbins_per_mam_bin
     ! Any dst constituent will work here.
     sm%sample_pmc_idx = pmc_idx_for_constituent('dst_a1')
 
-    ! The dust grid dust_dmt_grd already holds dust_nbin+1 bin edge diameters,
-    ! so sample_radius is just dust_dmt_grd / 2.
-    allocate(sm%sample_radius(dust_nbin + 1))
-    sm%sample_radius(:) = dust_dmt_grd(:) / 2.0d0
+    ! Build sub-bin edges: K-1 interior edges log-spaced within each MAM
+    ! bin, sharing edges with the next MAM bin. Total edges = n_samples + 1.
+    allocate(sm%sample_radius(sm%n_samples + 1))
+    isub = 0
+    do m = 1, dust_nbin
+       r_lo = dust_dmt_grd(m)   / 2.0d0
+       r_hi = dust_dmt_grd(m+1) / 2.0d0
+       log_ratio = log(r_hi / r_lo)
+       do k = 0, n_dust_subbins_per_mam_bin - 1
+          isub = isub + 1
+          sm%sample_radius(isub) = r_lo * exp( real(k, kind=dp) &
+               / real(n_dust_subbins_per_mam_bin, kind=dp) * log_ratio )
+       end do
+    end do
+    ! Final edge: top of last MAM bin.
+    sm%sample_radius(sm%n_samples + 1) = dust_dmt_grd(dust_nbin + 1) / 2.0d0
 
   end subroutine build_dust_sector_mode
 
@@ -1519,21 +1544,13 @@ end subroutine compute_partmc_emission_inputs
 
   ! Per-step inputs for the natural-source pseudo-modes (SEASALT, DUST).
   !
-  !   * Seasalt: fi(:ncol,:nsections) = sslt_sections::fluxes(cam_in%sst, u10cubed, ncol)
-  !              sample_num_conc(icol, seasalt_mode_idx, ibin) =
-  !                fi(icol, ibin) * cam_in%ocnfrac(icol) * seasalt_emis_scale
-  !   * Dust:    derive per-bin number from cam_in%dstflx + soil_erodibility +
-  !              dust_emis_sclfctr + dust_dmt_vwr (mass→number conversion).
-  !
-  ! TODO:The dust implementation is a first pass and needs improvement.
-  ! The bins are simply too large. The binned approach can be quite attractive when
-  ! we have many bins to resolve the size distribution in a way that we do not need to assume a
-  ! log-normal. For PartMC, we sample a diameters between bin edges uniformally.
-  ! This assumption is not ideal when the bins are large. This likely means that the smaller
-  ! particles will be oversampled in the smallest bin and the larger particles will be
-  ! oversampled in the last bin.
-  ! We may actually be best off with a log-normal approach for dust, or consider adding 
-  ! more bins to properly resolve the size and mass distribution.
+  !   * Seasalt: per-bin number flux from sslt_sections::fluxes(sst, u10cubed),
+  !              scaled by ocnfrac and seasalt_emis_scale.
+  !   * Dust:    per-MAM-bin mass from dust_model.F90:dust_emis logic
+  !              (cam_in%dstflx, dust_emis_sclfctr, soil_erodibility, soil_erod_fact),
+  !              split equally across n_dust_subbins_per_mam_bin sub-bins (uniform
+  !              mass per log(r) within each MAM bin), then converted to per-sub-bin
+  !              number via the volume-weighted moment over each sub-bin's edges.
   subroutine compute_partmc_natural_emission_inputs(state, cam_in, ncol, &
        u10cubed, sample_num_conc)
     use physics_types, only : physics_state
@@ -1541,7 +1558,7 @@ end subroutine compute_partmc_emission_inputs
     use ppgrid,        only : pver
     use sslt_sections, only : nsections, fluxes
     use aero_model,    only : seasalt_emis_scale
-    use dust_model,    only : dust_nbin, dust_emis_sclfctr, dust_dmt_vwr
+    use dust_model,    only : dust_nbin, dust_emis_sclfctr, dust_dmt_vwr, dust_indices
     use shr_dust_mod,  only : dust_emis_scheme
     use soil_erod_mod, only : soil_erodibility, soil_erod_fact
     use mo_constants,  only : dust_density
@@ -1565,8 +1582,9 @@ end subroutine compute_partmc_emission_inputs
     real(kind=dp) :: u10(pcols)
     real(kind=dp) :: fi_seasalt(pcols, nsections)
     real(kind=dp) :: soil_erod_val, mass_flux, x_mton
+    real(kind=dp) :: mass_subbin, r_lo, r_hi, r3_vw_subbin
     integer :: lchnk
-    integer :: icol, ibin, i_mode
+    integer :: icol, ibin, i_mode, isub, isub_in_bin, dust_icol
 
     sample_num_conc(:,:,:) = 0.0d0
     u10cubed(:) = 0.0d0
@@ -1615,16 +1633,21 @@ end subroutine compute_partmc_emission_inputs
           end if
        end if
        if ( trim(sector_modes(i_mode)%name) == 'emit_DUST' ) then
-          ! Per-column, per-bin dust mass and number flux. Direct port of the
-          ! per-column logic in dust_model.F90:dust_emis (lines 143-171).
-          ! Mass flux uses CLM-supplied dust_flux_in (in cam_in%dstflx),
-          ! rescaled by dust_emis_sclfctr per bin and weighted by soil
-          ! erodibility. Number is derived via x_mton = 6/(pi*rho*Dvwr^3).
+          ! Per-column dust mass per MAM bin (same scaling as dust_model.F90
+          ! dust_emis lines 143-171), then split equally across
+          ! n_dust_subbins_per_mam_bin sub-bins (uniform mass per log(r)
+          ! within each MAM bin). Per-sub-bin number is derived from
+          ! x_mton_sub = 6/(π·ρ·D_vw_sub³) where D_vw_sub³ = 8 × <r³> with
+          ! <r³>_sub = (r_hi³ - r_lo³) / (3·ln(r_hi/r_lo)) — the volume-
+          ! weighted moment for the assumed mass-per-log(r)-uniform shape.
+          ! This conserves the MAM-bin total mass exactly (the equal-mass
+          ! split summed over sub-bins recovers M_mam_bin) while letting
+          ! PartMC sample particles across the bin's full size range.
           !
           ! NOTE: aero_model.F90:2851-2868 caps total dust mass flux against
           ! dstemislimit and rescales the per-bin distribution if the cap is
-          ! hit. That cap is not applied here — for tightly comparable totals
-          ! against MAM's cflx it should be ported. Cap rarely triggers in
+          ! hit. That cap is not yet applied here but will not compare against
+          ! MAM's cflx unless added. Cap in theory rarely triggers in
           ! practice, so deferred for now.
           do icol = 1, ncol
              soil_erod_val = soil_erodibility(icol, lchnk)
@@ -1634,8 +1657,21 @@ end subroutine compute_partmc_emission_inputs
              do ibin = 1, dust_nbin
                 mass_flux = sum(-cam_in%dstflx(icol, :)) * 0.73d0 / 0.87d0 &
                      * dust_emis_sclfctr(ibin) * soil_erod_val / soil_erod_fact * 1.15d0
-                x_mton = 6.0d0 / (pi * dust_density * dust_dmt_vwr(ibin)**3)
-                sample_num_conc(icol, i_mode, ibin) = mass_flux * x_mton
+                ! TODO: switch from uniform-mass-per-log(r) to Kok11 brittle
+                ! fragmentation. Replace this equal split with
+                !     mass_subbin = mass_flux * w_kok11(isub_in_bin, ibin)
+                ! where w_kok11(:,:) is a precomputed weight array from integrate
+                ! Kok11's dV/dlogD over each sub-bin's edges, normalized so the
+                ! per-MAM-bin weights sum to 1.
+                mass_subbin = mass_flux / real(n_dust_subbins_per_mam_bin, kind=dp)
+                do isub_in_bin = 1, n_dust_subbins_per_mam_bin
+                   isub = (ibin - 1) * n_dust_subbins_per_mam_bin + isub_in_bin
+                   r_lo = sector_modes(i_mode)%sample_radius(isub)
+                   r_hi = sector_modes(i_mode)%sample_radius(isub + 1)
+                   r3_vw_subbin = (r_hi**3 - r_lo**3) / (3.0d0 * log(r_hi / r_lo))
+                   x_mton = 6.0d0 / (pi * dust_density * 8.0d0 * r3_vw_subbin)
+                   sample_num_conc(icol, i_mode, isub) = mass_subbin * x_mton
+                end do
              end do
           end do
 
@@ -1644,19 +1680,56 @@ end subroutine compute_partmc_emission_inputs
              write(102,*) 'Dust sample_num_conc (i_mode=', i_mode, ')'
              write(102,*) 'soil_erod_fact (from soil_erod_mod) = ', soil_erod_fact
              write(102,*) 'dust_emis_scheme (from shr_dust_mod) = ', dust_emis_scheme
+             write(102,*) 'n_dust_subbins_per_mam_bin = ', n_dust_subbins_per_mam_bin
              write(102,*) 'icol | soil_erod | dst_total | total num flux (m^-2 s^-1)'
              do icol = 1, ncol
                 soil_erod_val = soil_erodibility(icol, lchnk)
                 if ( dust_emis_scheme == 2 ) soil_erod_val = 1.0d0
                 if ( soil_erod_val < soil_erod_threshold ) soil_erod_val = 0.0d0
                 write(102,*) icol, soil_erod_val, sum(-cam_in%dstflx(icol, :)), &
-                     sum(sample_num_conc(icol, i_mode, 1:dust_nbin))
+                     sum(sample_num_conc(icol, i_mode, 1:sector_modes(i_mode)%n_samples))
              end do
-             write(102,*) 'Per-bin breakdown (icol = 1):'
-             write(102,*) 'ibin | radius edge low (m) | dmt_vwr (m) | num_conc (m^-2 s^-1)'
+             ! Pick a column that actually has dust emissions for the per-bin
+             ! breakdown — column 1 is often ocean/non-erodible, giving zeros.
+             dust_icol = 1
+             do icol = 1, ncol
+                if ( sum(sample_num_conc(icol, i_mode, &
+                         1:sector_modes(i_mode)%n_samples)) > 0.0d0 ) then
+                   dust_icol = icol
+                   exit
+                end if
+             end do
+
+             write(102,*) 'Per-MAM-bin aggregate (icol = ', dust_icol, '):'
+             write(102,*) 'ibin | mass PartMC | mass cflx(dst_aN) | num PartMC | num MAM-eqv | num cflx(num_aN)'
+             soil_erod_val = soil_erodibility(dust_icol, lchnk)
+             if ( dust_emis_scheme == 2 ) soil_erod_val = 1.0d0
+             if ( soil_erod_val < soil_erod_threshold ) soil_erod_val = 0.0d0
              do ibin = 1, dust_nbin
-                write(102,*) ibin, sector_modes(i_mode)%sample_radius(ibin), &
-                     dust_dmt_vwr(ibin), sample_num_conc(1, i_mode, ibin)
+                ! Mass flux for this MAM bin (same formula as the per-step compute above).
+                mass_flux = sum(-cam_in%dstflx(dust_icol, :)) * 0.73d0 / 0.87d0 &
+                     * dust_emis_sclfctr(ibin) * soil_erod_val / soil_erod_fact * 1.15d0
+                ! cflx(dst_aN) is natural-only (anthro doesn't write to dst slots),
+                ! so the mass comparison is clean. cflx(num_aN) mixes natural dust +
+                ! anthropogenic + seasalt by the time partmc_mam_invoke runs, so the
+                ! "num cflx" column won't match "num MAM-eqv" unless this is a pure
+                ! dust-only column.
+                x_mton = 6.0d0 / (pi * dust_density * dust_dmt_vwr(ibin)**3)
+                write(102,*) ibin, mass_flux, &
+                     cam_in%cflx(dust_icol, dust_indices(ibin)), &
+                     sum(sample_num_conc(dust_icol, i_mode, &
+                         (ibin-1)*n_dust_subbins_per_mam_bin + 1 : &
+                         ibin*n_dust_subbins_per_mam_bin)), &
+                     mass_flux * x_mton, &
+                     cam_in%cflx(dust_icol, dust_indices(ibin + dust_nbin))
+             end do
+
+             write(102,*) 'Per-sub-bin breakdown (icol = ', dust_icol, '):'
+             write(102,*) 'isub | r_lo (m) | r_hi (m) | num_conc (m^-2 s^-1)'
+             do isub = 1, sector_modes(i_mode)%n_samples
+                write(102,*) isub, sector_modes(i_mode)%sample_radius(isub), &
+                     sector_modes(i_mode)%sample_radius(isub + 1), &
+                     sample_num_conc(dust_icol, i_mode, isub)
              end do
              write(102,*) '-----------------------------------------'
           end if

--- a/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
+++ b/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
@@ -43,7 +43,7 @@ module mo_partmc_interface
     character(len=PMC_MAX_FILENAME_LEN) :: restart_filename
     integer :: dummy_index, dummy_i_repeat
     integer :: nmodes,nspec_max_modes
-    real(kind=dp) :: n_part
+    real(kind=dp) :: n_part_ideal
     ! mam information
     character(len=256), allocatable :: mam_num_names(:)
     character(len=256), allocatable :: mam_species_names(:,:)
@@ -216,7 +216,7 @@ subroutine compute_partmc_emission_inputs(cflx, ncol, geom_mean_diameter, std_ma
         sum_vf_per_mode(icol, n) = sum_vf_per_mode(icol, n) + volume_fractions(icol, n, ispec)
       end do
       if (masterproc) then
-            write(102,*) "volume_fractions(", 1, n, ",", spec_idx, "):", volume_fractions(1,n, spec_idx)
+            write(102,*) "volume_fractions(", 1, n, ",", ispec, "):", volume_fractions(1,n, ispec)
       end if
     end do
   end do
@@ -225,6 +225,7 @@ subroutine compute_partmc_emission_inputs(cflx, ncol, geom_mean_diameter, std_ma
   do n = 1, nmodes
     call rad_cnst_get_info(list_idx, n, nspec=nspec)
     do ispec = 1, nspec
+      call rad_cnst_get_mam_mmr_idx(n, ispec, spec_idx)
       idx_chm = map2chm(spec_idx)
         if (idx_chm > 0) then
           if (adv_mass(idx_chm) /= 0.0) then
@@ -245,7 +246,7 @@ end subroutine compute_partmc_emission_inputs
 
   subroutine spec_file_read_run_part_eam(run_part_opt, &
        env_state_init, &
-       n_part, rand_init)
+       n_part_ideal, rand_init)
 
     use rad_constituents, only: rad_cnst_get_info, rad_cnst_get_aer_props
     use modal_aero_data, only: &
@@ -256,7 +257,7 @@ end subroutine compute_partmc_emission_inputs
     !> Initial environmental state.
     type(env_state_t), intent(inout) :: env_state_init
     !> Ideal number of computational particles.
-    real(kind=dp), intent(inout) :: n_part
+    real(kind=dp), intent(inout) :: n_part_ideal
     !> Random number generator seed.
     integer, intent(out) :: rand_init
 
@@ -287,7 +288,7 @@ end subroutine compute_partmc_emission_inputs
     character(len=SPEC_LINE_MAX_VAR_LEN) :: weight_class_name
     character(len=20):: aername
 
-    n_part = 50
+    n_part_ideal = 50
 
     env_state_init%elapsed_time = 0d0
     
@@ -352,18 +353,18 @@ end subroutine compute_partmc_emission_inputs
    integer, dimension(:), intent(in) :: species_class
 
    integer :: i, n_species, n_aero_species, i_spec,i_mode, nspec
-   integer :: ncol, kk, icol, ichunk, idx_chm, num_idx, rank
+   integer :: ncol, kk, icol, ichunk, idx_chm, num_idx
    integer :: n_gas_species, nfs
-   integer :: ierr
+   integer :: rank, ierr ! Remove when debugging of processor removed
    character(len=100) :: file_name
    type(spec_file_t) :: file
    type(spec_file_t) :: sub_file
    type(aero_dist_t) :: aero_dist_init
    character(len=SPEC_LINE_MAX_VAR_LEN) :: weight_class_name
 
-   call mpi_comm_rank(MPI_COMM_WORLD, rank, ierr)
-
-   print*, 'MPI rank: ', rank, 'chunk start: ', begchunk, 'chunk end:', endchunk
+   ! Uncomment for processor information for debugging
+   !call mpi_comm_rank(MPI_COMM_WORLD, rank, ierr)
+   !print*, 'MPI rank: ', rank, 'chunk start: ', begchunk, 'chunk end:', endchunk
 
    ! Allocate aero_state for each column of each chunk
    allocate(aero_state_array(begchunk:endchunk))
@@ -408,7 +409,7 @@ end subroutine compute_partmc_emission_inputs
 
   call spec_file_read_run_part_eam(run_part_opt, &
        env_state_init, &
-       n_part, rand_init)
+       n_part_ideal, rand_init)
 
     allocate(aero_dist_init%mode(ntot_amode))
     do i_mode = 1,ntot_amode
@@ -428,6 +429,7 @@ end subroutine compute_partmc_emission_inputs
     end do
 
     do ichunk = begchunk,endchunk
+    ncol = phys_state(ichunk)%ncol
     do kk = 1,pver
     do icol = 1, ncol
        do i_mode = 1,ntot_amode
@@ -436,13 +438,15 @@ end subroutine compute_partmc_emission_inputs
           call rad_cnst_get_mode_num_idx(i_mode, num_idx)
           aero_dist_init%mode(i_mode)%char_radius = 1.0d-8
           aero_dist_init%mode(i_mode)%vol_frac = 1.0d0 / 20
-          aero_dist_init%mode(i_mode)%num_conc = 1e6 !+ 1e6*phys_state(ichunk)%lon(icol) ** 2
+          aero_dist_init%mode(i_mode)%num_conc = 1e6
+          write(102,*) i_mode, num_idx, idx_chm, phys_state(ichunk)%q(icol,kk,idx_chm), &
+               phys_state(ichunk)%q(icol,kk,num_idx)
 !          aero_dist_init%mode(i_mode)%num_conc = phys_state(ichunk)%q(icol,kk,idx_chm)
        end do
        call aero_state_zero(aero_state_array(ichunk)%aero_state(icol,kk))
        call aero_state_set_weight(aero_state_array(ichunk)%aero_state(icol,kk), aero_data, &
             AERO_STATE_WEIGHT_FLAT_SOURCE)
-       call aero_state_set_n_part_ideal(aero_state_array(ichunk)%aero_state(icol,kk), n_part)
+       call aero_state_set_n_part_ideal(aero_state_array(ichunk)%aero_state(icol,kk), n_part_ideal)
        call aero_state_add_aero_dist_sample(aero_state_array(ichunk)%aero_state(icol,kk), &
             aero_data, aero_dist_init, 1d0, 1d0, 0d0, run_part_opt%allow_doubling, &
             run_part_opt%allow_halving)
@@ -486,6 +490,10 @@ end subroutine compute_partmc_emission_inputs
     write(102,*) '-----------------------------------------'
   endif
 
+  if (masterproc) then
+           write(102,*) phys_state(begchunk)%q(1,pver,:)
+  end if
+
   end subroutine partmc_mam_inti
 
   subroutine partmc_mam_invoke(state, cflx, dt)
@@ -508,7 +516,7 @@ end subroutine compute_partmc_emission_inputs
     real(kind=dp) ::  num_fluxes(pcols, nmodes)
     real(kind=dp) ::  volume_fractions(pcols, nmodes, nspec_max_modes)
 
-    integer ::  n_samp, n_coag, i_time, n_time, n_emit,nmodes
+    integer ::  n_samp, n_coag, i_time, n_time, n_emit
     integer :: i_mode
     real(kind=dp) :: emission_rate_scale, p
     real(kind=dp) :: characteristic_factor
@@ -557,6 +565,9 @@ end subroutine compute_partmc_emission_inputs
           gas_state%mix_rat(i) = state%q(icol,kk,i) * 1d9
         end do ! species
 
+        if (masterproc) then
+           write(102,*) state%q(icol,kk,:)
+        end if
         ! FIXME: Think about how to best do this scenario/env_state.
         ! scenario%temp(:)  = state%t(icol,kk)
         ! scenario%pressure = state%pmid(icol,kk)
@@ -712,6 +723,7 @@ end subroutine compute_partmc_emission_inputs
   subroutine partmc_interface_e3sm_emissions(state, emissions, geom_mean_diam, &
       sigma, num_fluxes, vol_frac)
     use physics_types,    only : physics_state
+    use rad_constituents, only: rad_cnst_get_info
 
     implicit none
     type(physics_state), intent(in):: state
@@ -722,7 +734,7 @@ end subroutine compute_partmc_emission_inputs
     real(kind=dp), intent(in) ::  num_fluxes(nmodes)
     real(kind=dp), intent(in) ::  vol_frac(nmodes, nspec_max_modes)
 
-    integer :: i_mode, i_spec, n_spec_emit
+    integer :: i_mode, i_spec, n_spec_emit, ll
     character(len=AERO_MODE_NAME_LEN) :: mode_name
     character(len=SPEC_LINE_MAX_VAR_LEN) :: weight_class_name
 
@@ -745,9 +757,10 @@ end subroutine compute_partmc_emission_inputs
        allocate(emissions%mode(i_mode)%vol_frac_std(aero_data_n_spec(aero_data)))
        emissions%mode(i_mode)%vol_frac = 0.0d0
        ! number of species in this mode
-       n_spec_emit = 1
+       call rad_cnst_get_info(0, i_mode, nspec=n_spec_emit)
        do i_spec =1,n_spec_emit
-          emissions%mode(i_mode)%vol_frac(i_spec) = 1.0d0
+          ll = mam_spec_to_partmc_spec(i_mode,i_spec)
+          emissions%mode(i_mode)%vol_frac(ll) = vol_frac(i_mode,i_spec) 
        end do
        emissions%mode(i_mode)%vol_frac_std = 0.0d0
 

--- a/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
+++ b/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
@@ -43,6 +43,8 @@ module mo_partmc_interface
     character(len=PMC_MAX_FILENAME_LEN) :: restart_filename
     integer :: dummy_index, dummy_i_repeat
     integer :: nmodes,nspec_max_modes
+    integer, parameter :: list_idx = 0  ! Climate list (0) vs. diagnostic list
+    real(kind=dp), parameter :: third = 1.0d0 / 3.0d0
     real(kind=dp) :: n_part_ideal
     ! mam information
     character(len=256), allocatable :: mam_num_names(:)
@@ -141,7 +143,6 @@ subroutine compute_partmc_emission_inputs(cflx, ncol, geom_mean_diameter, std_ma
   real(kind=dp), intent(out) :: volume_fractions(:,:,:)  ! Volume fractions for each species
 
   ! Local variables
-  integer :: list_idx                          ! Index for climate or diagnostic list
   integer :: nspec                             ! Number of species in a mode
   integer :: n, ispec, icol                    ! Loop indices
   integer :: num_idx, spec_idx, idx_chm        ! Indices for number flux, species, and chemistry mapping
@@ -152,10 +153,8 @@ subroutine compute_partmc_emission_inputs(cflx, ncol, geom_mean_diameter, std_ma
   real(kind=dp) :: dryvol(ncol)                        ! Dry volume for each column
   real(kind=dp) :: specdens
   real(kind=dp) :: sum_vf_per_mode(ncol,nmodes)            ! Sum of mass mixing ratios per mode
-  real(kind=dp), parameter :: third = 1.0 / 3.0  ! Constant for cube root calculation
 
-  ! Initialize variables
-  list_idx = 0  ! Climate list by default
+
 
   ! Loop over modes to compute properties
   geom_mean_diameter(:,:)=0.0
@@ -654,12 +653,6 @@ end subroutine compute_partmc_emission_inputs
     integer :: i_mode, i_spec, kk, icol, ll
     integer :: num_idx, idx_chm, spec_idx, nspec
     real(kind=dp) :: dryvol, dumfac, dummwdens, dgnum_dry, num_a
-    real(kind=dp), parameter :: third = 1.0d0 / 3.0d0
-    integer :: list_idx
-
-    ! Initialize variables
-    list_idx = 0  ! Climate list by default
-
     lchnk = state%lchnk
     ncol  = state%ncol
 

--- a/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
+++ b/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
@@ -355,6 +355,7 @@ end subroutine compute_partmc_emission_inputs
    integer :: i, n_species, n_aero_species, i_spec,i_mode, nspec
    integer :: ncol, kk, icol, ichunk, idx_chm, num_idx
    integer :: n_gas_species, nfs
+   integer :: gas_species_idx(pcnst)
    integer :: rank, ierr ! Remove when debugging of processor removed
    character(len=100) :: file_name
    type(spec_file_t) :: file
@@ -377,9 +378,10 @@ end subroutine compute_partmc_emission_inputs
   ! Get number of actual (active) gas species.
   ! gas_pncst is "gas" species which apparently is not just gases.
   n_gas_species = 0
-  do i =1,pcnst
+  do i = 1, pcnst
      if (species_class(i) == spec_class_gas) then
         n_gas_species = n_gas_species + 1
+        gas_species_idx(n_gas_species) = i
      end if
   end do
 
@@ -391,8 +393,8 @@ end subroutine compute_partmc_emission_inputs
   call ensure_string_array_size(gas_data%name, n_gas_species)
   call gas_state_set_size(gas_state, n_gas_species)
 
-  do i = 1,n_gas_species
-     gas_data%name(i) = solsym(i)
+  do i = 1, n_gas_species
+     gas_data%name(i) = solsym(gas_species_idx(i))
   end do
 
   if (masterproc) then

--- a/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
+++ b/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
@@ -1336,6 +1336,14 @@ end subroutine compute_partmc_emission_inputs
           have_so4a1 = species_has_sector('so4_a1', trim(sector))
           have_so4a2 = species_has_sector('so4_a2', trim(sector))
 
+          ! NOTE: the three have_* blocks below are near-identical boilerplate
+          ! (set name/parent/sigma, allocate + fill mass and num arrays).
+          ! This should be refactored into an add_sector_mode helper
+          ! so adding a group is one data-driven call instead of a copied block.
+          ! However for readability, we will keep it explicit for now since we have
+          ! few groups and want the logic to be transparent especially for the primary
+          ! carbon mode.
+
           ! Handle hydrophobic BCPOM sectors -> MAM mode 4 (primary carbon; accumulation-sized).
           if (have_bcpom) then
              i_out = i_out + 1

--- a/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
+++ b/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
@@ -467,11 +467,7 @@ end subroutine compute_partmc_emission_inputs
     use cam_history,       only : outfld
     use constituents,     only: pcnst
     use mo_chem_utls,        only : get_spc_ndx
-    use rad_constituents, only: rad_cnst_get_info, rad_cnst_get_mode_num_idx, rad_cnst_get_mam_mmr_idx
     use physconst,    only: spec_class_aerosol, spec_class_gas
-    use mo_gas_phase_chemdr, only : map2chm
-    use modal_aero_data, only: ntot_amode, modename_amode, sigmag_amode, &
-       nspec_amode, numptr_amode, lmassptr_amode
 
     type(physics_state), intent(inout):: state
     real(kind=dp),       intent(in) :: cflx(pcols,pcnst)              ! constituent surface flux (kg/m^2/s)
@@ -491,12 +487,6 @@ end subroutine compute_partmc_emission_inputs
     real(kind=dp) :: emission_rate_scale, p
     real(kind=dp) :: characteristic_factor
     type(aero_dist_t) :: emissions
-    type(aero_dist_t) :: aero_dist_init
-    character(len=SPEC_LINE_MAX_VAR_LEN) :: weight_class_name
-    integer :: num_idx, idx_chm, spec_idx
-    integer :: nspec, i_spec, n
-    real(kind=dp), parameter :: third = 1.0 / 3.0
-    real(kind=dp) :: dryvol, dumfac, dummwdens, dgncur_a, num_a
 
     !FIXME: we must pass a delta time factor
     n_time = 30
@@ -511,61 +501,7 @@ end subroutine compute_partmc_emission_inputs
     ! (phys_state%q is not populated until d_p_coupling runs before the first
     ! timestep, which is after partmc_mam_inti is called during phys_init.)
     if (.not. q_init_saved(lchnk)) then
-       allocate(aero_dist_init%mode(ntot_amode))
-       do i_mode = 1,ntot_amode
-          aero_dist_init%mode(i_mode)%name = modename_amode(i_mode)
-          aero_dist_init%mode(i_mode)%type = AERO_MODE_TYPE_LOG_NORMAL
-          aero_dist_init%mode(i_mode)%source = aero_data_source_by_name(aero_data, &
-               aero_dist_init%mode(i_mode)%name)
-          weight_class_name = aero_dist_init%mode(i_mode)%name
-          aero_dist_init%mode(i_mode)%weight_class = aero_data_weight_class_by_name(aero_data, &
-               weight_class_name)
-          aero_dist_init%mode(i_mode)%log10_std_dev_radius = log10(sigmag_amode(i_mode))
-          allocate(aero_dist_init%mode(i_mode)%vol_frac(aero_data_n_spec(aero_data)))
-          allocate(aero_dist_init%mode(i_mode)%vol_frac_std(aero_data_n_spec(aero_data)))
-          aero_dist_init%mode(i_mode)%vol_frac_std = 0.0d0
-          aero_dist_init%mode(i_mode)%sample_radius = [ real(kind=dp) :: ]
-          aero_dist_init%mode(i_mode)%sample_num_conc = [ real(kind=dp) :: ]
-       end do
-       do kk = 1,pver
-          do icol = 1,ncol
-             do i_mode = 1,ntot_amode
-                ! Set number concentration of the mode
-                num_idx = numptr_amode(i_mode)
-                idx_chm = map2chm(num_idx)
-                call rad_cnst_get_mode_num_idx(i_mode, num_idx)
-                aero_dist_init%mode(i_mode)%num_conc = state%q(icol,kk,num_idx)
-                aero_dist_init%mode(i_mode)%vol_frac = 0.0d0
-                ! Set volume fraction of the mode
-                call rad_cnst_get_info(0, i_mode, nspec=nspec)
-                dryvol = 0.d0
-                do i_spec = 1, nspec
-                    call rad_cnst_get_mam_mmr_idx(i_mode, i_spec, spec_idx)
-                    idx_chm = map2chm(spec_idx)
-                    ! Convert from mass mixing ratio to volume fraction using density
-                    aero_dist_init%mode(i_mode)%vol_frac(spec_idx) = &
-                        state%q(icol,kk,idx_chm) / aero_data%density(spec_idx)
-                    ! Compute dry volume of mode for diameter calculation
-                    dummwdens = 1.0d0 / aero_data%density(spec_idx)
-                    dryvol = dryvol + max(0.0d0, state%q(icol,kk,idx_chm))*dummwdens
-                end do
-                
-                ! Calculate geometric median diameter
-                dumfac = exp(4.5d0*log(sigmag_amode(i_mode))**2)*const%pi/6.0d0
-                dgncur_a = (dryvol/(dumfac*num_a))**third
-                aero_dist_init%mode(i_mode)%char_radius = dgncur_a / 2.0d0
-                !if (masterproc)
-                   !write(102,*) i_mode, num_idx, idx_chm, phys_state(ichunk)%q(icol,kk,idx_chm), &
-                        !phys_state(ichunk)%q(icol,kk,num_idx)
-                !endif
-             end do
-             call aero_state_add_aero_dist_sample(aero_state_array(lchnk)%aero_state(icol,kk), &
-                  aero_data, aero_dist_init, 1d0, 1d0, 0d0, run_part_opt%allow_doubling, &
-                  run_part_opt%allow_halving)
-          end do
-       end do
-       ! Set the flag to indicate that initial values have been set for this chunk
-       q_init_saved(lchnk) = .true.
+       call partmc_init_aero_dist(state)
     end if
 
     ! Output arrays
@@ -703,6 +639,84 @@ end subroutine compute_partmc_emission_inputs
     call outfld( 'aero_num_conc', aero_num_conc_out(:ncol, :, :), ncol, lchnk )
 
   end subroutine partmc_mam_invoke
+
+  ! Populates aero_state_array with the initial aerosol distribution for chunk
+  ! lchnk from the first-timestep values of physics_state%q.
+  subroutine partmc_init_aero_dist(state)
+    use physics_types,    only : physics_state
+    use rad_constituents, only: rad_cnst_get_info, rad_cnst_get_mode_num_idx, rad_cnst_get_mam_mmr_idx
+    use mo_gas_phase_chemdr, only : map2chm
+    use modal_aero_data, only: ntot_amode, modename_amode, sigmag_amode, numptr_amode
+
+    type(physics_state), intent(in) :: state
+
+    integer :: lchnk, ncol
+    type(aero_dist_t) :: aero_dist_init
+    character(len=SPEC_LINE_MAX_VAR_LEN) :: weight_class_name
+    integer :: i_mode, i_spec, kk, icol
+    integer :: num_idx, idx_chm, spec_idx, nspec
+    real(kind=dp) :: dryvol, dumfac, dummwdens, dgncur_a, num_a
+    real(kind=dp), parameter :: third = 1.0 / 3.0
+
+    lchnk = state%lchnk
+    ncol  = state%ncol
+
+    allocate(aero_dist_init%mode(ntot_amode))
+    do i_mode = 1,ntot_amode
+       aero_dist_init%mode(i_mode)%name = modename_amode(i_mode)
+       aero_dist_init%mode(i_mode)%type = AERO_MODE_TYPE_LOG_NORMAL
+       aero_dist_init%mode(i_mode)%source = aero_data_source_by_name(aero_data, &
+            aero_dist_init%mode(i_mode)%name)
+       weight_class_name = aero_dist_init%mode(i_mode)%name
+       aero_dist_init%mode(i_mode)%weight_class = aero_data_weight_class_by_name(aero_data, &
+            weight_class_name)
+       aero_dist_init%mode(i_mode)%log10_std_dev_radius = log10(sigmag_amode(i_mode))
+       allocate(aero_dist_init%mode(i_mode)%vol_frac(aero_data_n_spec(aero_data)))
+       allocate(aero_dist_init%mode(i_mode)%vol_frac_std(aero_data_n_spec(aero_data)))
+       aero_dist_init%mode(i_mode)%vol_frac_std = 0.0d0
+       aero_dist_init%mode(i_mode)%sample_radius = [ real(kind=dp) :: ]
+       aero_dist_init%mode(i_mode)%sample_num_conc = [ real(kind=dp) :: ]
+    end do
+    do kk = 1,pver
+       do icol = 1,ncol
+          do i_mode = 1,ntot_amode
+             ! Set number concentration of the mode
+             num_idx = numptr_amode(i_mode)
+             idx_chm = map2chm(num_idx)
+             call rad_cnst_get_mode_num_idx(i_mode, num_idx)
+             aero_dist_init%mode(i_mode)%num_conc = state%q(icol,kk,num_idx)
+             aero_dist_init%mode(i_mode)%vol_frac = 0.0d0
+             ! Set volume fraction of the mode
+             call rad_cnst_get_info(0, i_mode, nspec=nspec)
+             dryvol = 0.d0
+             do i_spec = 1,nspec
+                call rad_cnst_get_mam_mmr_idx(i_mode, i_spec, spec_idx)
+                idx_chm = map2chm(spec_idx)
+                ! Convert from mass mixing ratio to volume fraction using density
+                aero_dist_init%mode(i_mode)%vol_frac(spec_idx) = &
+                     state%q(icol,kk,idx_chm) / aero_data%density(spec_idx)
+                ! Compute dry volume of mode for diameter calculation
+                dummwdens = 1.0d0 / aero_data%density(spec_idx)
+                dryvol = dryvol + max(0.0d0, state%q(icol,kk,idx_chm))*dummwdens
+             end do
+
+             ! Calculate geometric median diameter
+             dumfac = exp(4.5d0*log(sigmag_amode(i_mode))**2)*const%pi/6.0d0
+             dgncur_a = (dryvol/(dumfac*num_a))**third
+             aero_dist_init%mode(i_mode)%char_radius = dgncur_a / 2.0d0
+             !if (masterproc)
+                !write(102,*) i_mode, num_idx, idx_chm, phys_state(ichunk)%q(icol,kk,idx_chm), &
+                     !phys_state(ichunk)%q(icol,kk,num_idx)
+             !endif
+          end do
+          call aero_state_add_aero_dist_sample(aero_state_array(lchnk)%aero_state(icol,kk), &
+               aero_data, aero_dist_init, 1d0, 1d0, 0d0, run_part_opt%allow_doubling, &
+               run_part_opt%allow_halving)
+       end do
+    end do
+    q_init_saved(lchnk) = .true.
+
+  end subroutine partmc_init_aero_dist
 
   ! Compute bulk statistics
   subroutine write_nc_aero_state(aero_state, &

--- a/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
+++ b/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
@@ -70,7 +70,7 @@ contains
   nspec_max = 0
   ! Loop over modes to find the maximum number of species
   do n = 1, nmodes
-    call rad_cnst_get_info(0, n, nspec=nspec)
+    call rad_cnst_get_info(list_idx, n, nspec=nspec)
     nspec_max = max(nspec_max, nspec)
   end do
 
@@ -107,7 +107,7 @@ subroutine save_num_and_species_names(num_names, species_names)
 
     ! Loop over species in the mode to retrieve names
     ! Get the number of species in the mode
-    call rad_cnst_get_info(0, n, nspec=nspec)
+    call rad_cnst_get_info(list_idx, n, nspec=nspec)
     do ispec = 1, nspec
       ! Get the species index for the mode and species
       call rad_cnst_get_mam_mmr_idx(n, ispec, spec_idx)
@@ -384,7 +384,7 @@ end subroutine compute_partmc_emission_inputs
     end if
 
     ! Initialization of aerosol data
-    call rad_cnst_get_info(0, nmodes=nmodes)
+    call rad_cnst_get_info(list_idx, nmodes=nmodes)
     call compute_nspec_max(nspec_max_modes)
     call aero_data_init(aero_data)
 
@@ -447,7 +447,7 @@ end subroutine compute_partmc_emission_inputs
        write(102,*) 'save_num_and_species_names'
        do i_mode = 1,nmodes
           write(102, "(A)", advance="no") "Mode " // trim(adjustl(mam_num_names(i_mode))) // ": "
-          call rad_cnst_get_info(0, i_mode, nspec=nspec)
+          call rad_cnst_get_info(list_idx, i_mode, nspec=nspec)
           do i_spec = 1,nspec
              write(102, "(A)", advance="no") trim(adjustl(mam_species_names(i_mode, i_spec))) // " "
           end do
@@ -653,6 +653,7 @@ end subroutine compute_partmc_emission_inputs
     integer :: i_mode, i_spec, kk, icol, ll
     integer :: num_idx, idx_chm, spec_idx, nspec
     real(kind=dp) :: dryvol, dumfac, dummwdens, dgnum_dry, num_a
+
     lchnk = state%lchnk
     ncol  = state%ncol
 
@@ -814,7 +815,7 @@ end subroutine compute_partmc_emission_inputs
        allocate(emissions%mode(i_mode)%vol_frac_std(aero_data_n_spec(aero_data)))
        emissions%mode(i_mode)%vol_frac = 0.0d0
        ! number of species in this mode
-       call rad_cnst_get_info(0, i_mode, nspec=n_spec_emit)
+       call rad_cnst_get_info(list_idx, i_mode, nspec=n_spec_emit)
        do i_spec =1,n_spec_emit
           ll = mam_spec_to_partmc_spec(i_mode,i_spec)
           emissions%mode(i_mode)%vol_frac(ll) = vol_frac(i_mode,i_spec) 
@@ -860,12 +861,12 @@ end subroutine compute_partmc_emission_inputs
     if (masterproc) then
       ! Number of aerosol chemical species defined (over all modes)
       print*, 'number of total aerosol species', ntot_aspectype
-      call rad_cnst_get_info(0, nmodes=n_modes)
+      call rad_cnst_get_info(list_idx, nmodes=n_modes)
       do m = 1,n_modes
          ! Properties of modal species
-         call rad_cnst_get_info(0, m, nspec=n_spec)
+         call rad_cnst_get_info(list_idx, m, nspec=n_spec)
          do l = 1,n_spec
-            call rad_cnst_get_aer_props(0, m, l, &
+            call rad_cnst_get_aer_props(list_idx, m, l, &
                aername = aername, &
                density_aer = density, &
                hygro_aer   = hygro)
@@ -879,10 +880,10 @@ end subroutine compute_partmc_emission_inputs
     end if
 
     ! Unique strings of the aername in the modes
-    call rad_cnst_get_info(0, nmodes=n_modes)
+    call rad_cnst_get_info(list_idx, nmodes=n_modes)
     total_mam_vars = 0
     do m =1,n_modes
-       call rad_cnst_get_info(0, m, nspec=n_spec)
+       call rad_cnst_get_info(list_idx, m, nspec=n_spec)
        total_mam_vars = total_mam_vars + n_spec
     end do
     allocate(input_array(total_mam_vars))
@@ -896,9 +897,9 @@ end subroutine compute_partmc_emission_inputs
 
     i_name = 0 
     do m = 1,n_modes
-       call rad_cnst_get_info(0, m, nspec=n_spec)
+       call rad_cnst_get_info(list_idx, m, nspec=n_spec)
        do l = 1,n_spec
-          call rad_cnst_get_aer_props(0, m, l, &
+          call rad_cnst_get_aer_props(list_idx, m, l, &
                aername = aername, &
                density_aer = density, &
                hygro_aer = hygro)
@@ -978,9 +979,9 @@ end subroutine compute_partmc_emission_inputs
     allocate(mam_spec_to_partmc_spec(n_modes, nspec_max_modes))
     mam_spec_to_partmc_spec = 0
     do m = 1,n_modes
-       call rad_cnst_get_info(0, m, nspec=n_spec)
+       call rad_cnst_get_info(list_idx, m, nspec=n_spec)
        do l = 1,n_spec
-          call rad_cnst_get_aer_props(0, m, l, &
+          call rad_cnst_get_aer_props(list_idx, m, l, &
                aername = aername)
           ! Find the index
           mam_spec_to_partmc_spec(m,l) = aero_data_spec_by_name(aero_data, aername) 

--- a/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
+++ b/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
@@ -415,9 +415,11 @@ end subroutine compute_partmc_emission_inputs
           aero_dist_init%mode(i_mode)%char_radius = 1.0d-8
           aero_dist_init%mode(i_mode)%vol_frac = 1.0d0 / 20
           aero_dist_init%mode(i_mode)%num_conc = 1e6
-          write(102,*) i_mode, num_idx, idx_chm, phys_state(ichunk)%q(icol,kk,idx_chm), &
-               phys_state(ichunk)%q(icol,kk,num_idx)
-!          aero_dist_init%mode(i_mode)%num_conc = phys_state(ichunk)%q(icol,kk,idx_chm)
+          !if (masterproc)
+             !write(102,*) i_mode, num_idx, idx_chm, phys_state(ichunk)%q(icol,kk,idx_chm), &
+                  !phys_state(ichunk)%q(icol,kk,num_idx)
+          !endif
+          !aero_dist_init%mode(i_mode)%num_conc = phys_state(ichunk)%q(icol,kk,idx_chm)
        end do
        call aero_state_zero(aero_state_array(ichunk)%aero_state(icol,kk))
        call aero_state_set_weight(aero_state_array(ichunk)%aero_state(icol,kk), aero_data, &
@@ -446,8 +448,6 @@ end subroutine compute_partmc_emission_inputs
        'number concentration for each particle' )
 
   ! Get the number of modes
-!  call rad_cnst_get_info(0, nmodes=nmodes)
-!  call compute_nspec_max(nspec_max_modes)
   allocate(mam_num_names(nmodes))
   allocate(mam_species_names(nmodes, nspec_max_modes))
   call save_num_and_species_names(mam_num_names,mam_species_names)
@@ -466,9 +466,10 @@ end subroutine compute_partmc_emission_inputs
     write(102,*) '-----------------------------------------'
   endif
 
-  if (masterproc) then
-           write(102,*) phys_state(begchunk)%q(1,pver,:)
-  end if
+  ! Debugging
+  !if (masterproc) then
+  !   write(102,*) phys_state(begchunk)%q(1,pver,:)
+  !end if
 
   end subroutine partmc_mam_inti
 

--- a/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
+++ b/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
@@ -644,7 +644,6 @@ end subroutine compute_partmc_emission_inputs
     use rad_constituents, only: rad_cnst_get_info, rad_cnst_get_mode_num_idx, rad_cnst_get_mam_mmr_idx
     use mo_gas_phase_chemdr, only : map2chm
     use modal_aero_data, only: ntot_amode, modename_amode, sigmag_amode, numptr_amode
-    use physconst,       only: rgas
 
     type(physics_state), intent(in) :: state
 
@@ -711,8 +710,8 @@ end subroutine compute_partmc_emission_inputs
              end if
              aero_dist_init%mode(i_mode)%char_radius = dgnum_dry / 2.0d0
              ! Convert number mixing ratio (#/kg_air) to number concentration (#/m^3)
-             aero_dist_init%mode(i_mode)%num_conc = num_a &
-                  * state%pmid(icol,kk) / (rgas * state%t(icol,kk))
+             aero_dist_init%mode(i_mode)%num_conc = num_a * state%pmid(icol,kk) &
+                  / (const%univ_gas_const / const%air_molec_weight * state%t(icol,kk))
           end do
           if (masterproc) then
              if (icol == 1 .and. kk == pver) then

--- a/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
+++ b/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
@@ -299,7 +299,10 @@ end subroutine compute_partmc_emission_inputs
     run_part_opt%t_progress = 0
 
     ! run_part_opt process settings
-    run_part_opt%do_coagulation = .true.
+    ! Coagulation disabled for now since it is slow and we want to
+    ! focus on emissions and getting the interface working.
+    ! Add it back later by changing to true.
+    run_part_opt%do_coagulation = .false.
     run_part_opt%coag_kernel_type = COAG_KERNEL_TYPE_BROWN
     run_part_opt%do_condensation = .false.
     run_part_opt%do_mosaic = .false.
@@ -638,9 +641,10 @@ end subroutine compute_partmc_emission_inputs
            end if
 
            ! Coagulation
-           ! DISABLED
-           ! call mc_coag(run_part_opt%coag_kernel_type, env_state, &
-           !      aero_data, aero_state, run_part_opt%del_t, n_samp, n_coag)
+           if (run_part_opt%do_coagulation) then
+              call mc_coag(run_part_opt%coag_kernel_type, env_state, &
+                   aero_data, aero_state, run_part_opt%del_t, n_samp, n_coag)
+           end if
 
            ! Rebalance
            call aero_state_rebalance(aero_state_array(lchnk)%aero_state(icol,kk), aero_data, &

--- a/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
+++ b/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
@@ -1283,6 +1283,29 @@ end subroutine compute_partmc_emission_inputs
           end if
        end do
 
+       ! Natural-source scaffolding: register one pseudo-mode per natural source
+       ! so aero_data knows about the source/weight-class names. Real bin-resolved
+       ! fluxes from seasalt_emis / dust_emis get wired in later.
+       i_out = i_out + 1
+       if (i_pass == 2) then
+          sector_modes(i_out)%name = 'emit_SEASALT'
+          sector_modes(i_out)%sector = 'OCEAN'
+          sector_modes(i_out)%parent_mam_mode = 0
+          sector_modes(i_out)%sigma_g = sigmag_amode(1)  ! placeholder until sampled-mode wiring
+          sector_modes(i_out)%n_mass = 0
+          sector_modes(i_out)%n_num  = 0
+       end if
+
+       i_out = i_out + 1
+       if (i_pass == 2) then
+          sector_modes(i_out)%name = 'emit_DUST'
+          sector_modes(i_out)%sector = 'LAND'
+          sector_modes(i_out)%parent_mam_mode = 0
+          sector_modes(i_out)%sigma_g = sigmag_amode(3)  ! placeholder until sampled-mode wiring
+          sector_modes(i_out)%n_mass = 0
+          sector_modes(i_out)%n_num  = 0
+       end if
+
        if (i_pass == 1) then
           n_emit_mode = i_out
           allocate(sector_modes(n_emit_mode))

--- a/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
+++ b/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
@@ -181,7 +181,7 @@ subroutine compute_partmc_emission_inputs(cflx, ncol, geom_mean_diameter, std_ma
     end if
 
     ! Compute number fluxes
-    do icol = 1, ncol
+    do icol = 1,ncol
       num_fluxes(icol, n) = cflx(icol, num_idx)
     end do
 
@@ -190,13 +190,13 @@ subroutine compute_partmc_emission_inputs(cflx, ncol, geom_mean_diameter, std_ma
       call rad_cnst_get_mam_mmr_idx(n, ispec, spec_idx)
       call rad_cnst_get_aer_props(list_idx, n, ispec, density_aer=specdens)
       dummwdens = 1.0 / specdens
-      do icol = 1, ncol
+      do icol = 1,ncol
         dryvol(icol) = dryvol(icol) + max(0.0, cflx(icol, spec_idx)) * dummwdens
       end do
     end do
 
     ! Compute geometric mean diameter
-    do icol = 1, ncol
+    do icol = 1,ncol
       if (num_fluxes(icol, n) /= 0) then
         geom_mean_diameter(icol, n) = (dryvol(icol) / (dumfac * num_fluxes(icol, n)))**third
       end if
@@ -207,7 +207,7 @@ subroutine compute_partmc_emission_inputs(cflx, ncol, geom_mean_diameter, std_ma
   end do
 
   ! Compute volume fractions
-  volume_fractions(:, :, :)=0.0
+  volume_fractions(:, :, :) =0.0
   sum_vf_per_mode(:,:) = 0.0
   do n = 1, nmodes
     call rad_cnst_get_info(list_idx, n, nspec=nspec)
@@ -215,7 +215,7 @@ subroutine compute_partmc_emission_inputs(cflx, ncol, geom_mean_diameter, std_ma
       call rad_cnst_get_mam_mmr_idx(n, ispec, spec_idx)
       call rad_cnst_get_aer_props(list_idx, n, ispec, density_aer=specdens)
       dummwdens = 1.0 / specdens
-      do icol = 1, ncol
+      do icol = 1,ncol
         volume_fractions(icol, n, ispec) =  cflx(icol, spec_idx) * dummwdens
         sum_vf_per_mode(icol, n) = sum_vf_per_mode(icol, n) + volume_fractions(icol, n, ispec)
       end do
@@ -233,7 +233,7 @@ subroutine compute_partmc_emission_inputs(cflx, ncol, geom_mean_diameter, std_ma
       idx_chm = map2chm(spec_idx)
         if (idx_chm > 0) then
           if (adv_mass(idx_chm) /= 0.0) then
-            do icol = 1, ncol
+            do icol = 1,ncol
               if (sum_vf_per_mode(icol, n) /= 0.0) then
                 volume_fractions(icol, n, ispec) = volume_fractions(icol, n, ispec) / sum_vf_per_mode(icol, n)
               end if
@@ -317,87 +317,82 @@ end subroutine compute_partmc_emission_inputs
 
   ! Initializes the data structures of PartMC.
   subroutine partmc_mam_inti(phys_state, species_class)
-   use mo_tracname, only : solsym
-   use cam_history,  only : addfld
-   use cam_history_support, only: add_hist_coord
-   use mo_chem_utls,        only : get_spc_ndx
-   use rad_constituents, only: rad_cnst_get_info, rad_cnst_get_mode_num_idx
-   use constituents,     only: pcnst
-   use physconst,    only: spec_class_aerosol, spec_class_gas
-   use physics_types,    only : physics_state
-   use mo_gas_phase_chemdr, only : map2chm
-   use modal_aero_data, only: ntot_amode, modename_amode, sigmag_amode, &
-       nspec_amode, numptr_amode, lmassptr_amode
-   use mpi
+    use mo_tracname, only : solsym
+    use cam_history,  only : addfld
+    use cam_history_support, only: add_hist_coord
+    use mo_chem_utls,        only : get_spc_ndx
+    use rad_constituents, only: rad_cnst_get_info, rad_cnst_get_mode_num_idx
+    use constituents,     only: pcnst
+    use physconst,    only: spec_class_aerosol, spec_class_gas
+    use physics_types,    only : physics_state
+    use mo_gas_phase_chemdr, only : map2chm
+    use modal_aero_data, only: ntot_amode, modename_amode, sigmag_amode, &
+         nspec_amode, numptr_amode, lmassptr_amode
+    use mpi
 
-   implicit none
+    type(physics_state), intent(in) :: phys_state(begchunk:endchunk)
+    integer, dimension(:), intent(in) :: species_class
 
-   type(physics_state), intent(in) :: phys_state(begchunk:endchunk)
-   integer, dimension(:), intent(in) :: species_class
+    integer :: i, i_spec, i_mode, nspec
+    integer :: ncol, kk, icol, ichunk, idx_chm, num_idx
+    integer :: n_gas_species
+    integer :: gas_species_idx(pcnst)
+    integer :: rank, ierr ! Remove when debugging of processor removed
+    type(aero_dist_t) :: aero_dist_init
+    character(len=SPEC_LINE_MAX_VAR_LEN) :: weight_class_name
 
-   integer :: i, i_spec, i_mode, nspec
-   integer :: ncol, kk, icol, ichunk, idx_chm, num_idx
-   integer :: n_gas_species
-   integer :: gas_species_idx(pcnst)
-   integer :: rank, ierr ! Remove when debugging of processor removed
-   type(aero_dist_t) :: aero_dist_init
-   character(len=SPEC_LINE_MAX_VAR_LEN) :: weight_class_name
+    ! Uncomment for processor information for debugging
+    !call mpi_comm_rank(MPI_COMM_WORLD, rank, ierr)
+    !print*, 'MPI rank: ', rank, 'chunk start: ', begchunk, 'chunk end:', endchunk
 
-   ! Uncomment for processor information for debugging
-   !call mpi_comm_rank(MPI_COMM_WORLD, rank, ierr)
-   !print*, 'MPI rank: ', rank, 'chunk start: ', begchunk, 'chunk end:', endchunk
+    ! Allocate aero_state for each column of each chunk
+    allocate(aero_state_array(begchunk:endchunk))
+    do i = begchunk, endchunk
+       ncol = phys_state(i)%ncol
+       allocate(aero_state_array(i)%aero_state(ncol,pver))
+    end do
 
-   ! Allocate aero_state for each column of each chunk
-   allocate(aero_state_array(begchunk:endchunk))
-   do i = begchunk, endchunk
-      ncol = phys_state(i)%ncol
-      allocate(aero_state_array(i)%aero_state(ncol,pver))
-   end do
+    ! Allocate storage for initial q (captured on first invoke, not here,
+    ! because phys_state%q is not yet populated at inti time)
+    allocate(q_init(begchunk:endchunk, pcols, pver, pcnst))
+    allocate(q_init_saved(begchunk:endchunk))
+    q_init_saved(:) = .false.
 
-   ! Allocate storage for initial q (captured on first invoke, not here,
-   ! because phys_state%q is not yet populated at inti time)
-   allocate(q_init(begchunk:endchunk, pcols, pver, pcnst))
-   allocate(q_init_saved(begchunk:endchunk))
-   q_init_saved(:) = .false.
+    ! Get number of actual (active) gas species.
+    ! gas_pncst is "gas" species which apparently is not just gases.
+    n_gas_species = 0
+    do i = 1,pcnst
+       if (species_class(i) == spec_class_gas) then
+          n_gas_species = n_gas_species + 1
+          gas_species_idx(n_gas_species) = i
+       end if
+    end do
 
-  ! n_aero_species=7 ! get from eam
-  ! Get number of actual (active) gas species.
-  ! gas_pncst is "gas" species which apparently is not just gases.
-  n_gas_species = 0
-  do i = 1, pcnst
-     if (species_class(i) == spec_class_gas) then
-        n_gas_species = n_gas_species + 1
-        gas_species_idx(n_gas_species) = i
-     end if
-  end do
+    if (masterproc) then
+       print*, 'number of active (?) gas species', n_gas_species
+    end if
 
-  if (masterproc) then
-     print*, 'number of active (?) gas species', n_gas_species
-!     print*, 'number of fixed gas species if we need it', nfs
-  end if
+    call ensure_string_array_size(gas_data%name, n_gas_species)
+    call gas_state_set_size(gas_state, n_gas_species)
 
-  call ensure_string_array_size(gas_data%name, n_gas_species)
-  call gas_state_set_size(gas_state, n_gas_species)
+    do i = 1,n_gas_species
+       gas_data%name(i) = solsym(gas_species_idx(i))
+    end do
 
-  do i = 1, n_gas_species
-     gas_data%name(i) = solsym(gas_species_idx(i))
-  end do
+    if (masterproc) then
+       write(*,*) 'PartMC gas_data names'
+       do i = 1,gas_data_n_spec(gas_data)
+          write(*,*) trim(gas_data%name(i))
+       end do
+    end if
 
-  if (masterproc) then
-     write(*,*) 'PartMC gas_data names'
-     do i =1, gas_data_n_spec(gas_data)
-        write(*,*) trim(gas_data%name(i))
-     end do
-  end if
+    ! Initialization of aerosol data
+    call rad_cnst_get_info(0, nmodes=nmodes)
+    call compute_nspec_max(nspec_max_modes)
+    call aero_data_init(aero_data)
 
-  ! Initialization of aerosol data
-  call rad_cnst_get_info(0, nmodes=nmodes)
-  call compute_nspec_max(nspec_max_modes)
-  call aero_data_init(aero_data)
-
-  call spec_file_read_run_part_eam(run_part_opt, &
-       env_state_init, &
-       n_part_ideal, rand_init)
+    call spec_file_read_run_part_eam(run_part_opt, &
+         env_state_init, n_part_ideal, rand_init)
 
     ! Make initial condition modes exist
     allocate(aero_dist_init%mode(ntot_amode))
@@ -405,7 +400,7 @@ end subroutine compute_partmc_emission_inputs
        aero_dist_init%mode(i_mode)%name =  modename_amode(i_mode)
        aero_dist_init%mode(i_mode)%type = AERO_MODE_TYPE_LOG_NORMAL
        aero_dist_init%mode(i_mode)%source = aero_data_source_by_name(aero_data, &
-           aero_dist_init%mode(i_mode)%name)
+            aero_dist_init%mode(i_mode)%name)
        weight_class_name = aero_dist_init%mode(i_mode)%name
        aero_dist_init%mode(i_mode)%weight_class = aero_data_weight_class_by_name(aero_data, &
             weight_class_name)
@@ -419,55 +414,50 @@ end subroutine compute_partmc_emission_inputs
 
     ! Set the weighting schemes and number of ideal particles for each aero_state
     do ichunk = begchunk,endchunk
-    ncol = phys_state(ichunk)%ncol
-    do kk = 1,pver
-    do icol = 1, ncol
-       call aero_state_zero(aero_state_array(ichunk)%aero_state(icol,kk))
-       call aero_state_set_weight(aero_state_array(ichunk)%aero_state(icol,kk), aero_data, &
-            AERO_STATE_WEIGHT_FLAT_SOURCE)
-       call aero_state_set_n_part_ideal(aero_state_array(ichunk)%aero_state(icol,kk), n_part_ideal)
+       ncol = phys_state(ichunk)%ncol
+       do kk = 1,pver
+          do icol = 1,ncol
+             call aero_state_zero(aero_state_array(ichunk)%aero_state(icol,kk))
+             call aero_state_set_weight(aero_state_array(ichunk)%aero_state(icol,kk), aero_data, &
+                  AERO_STATE_WEIGHT_FLAT_SOURCE)
+             call aero_state_set_n_part_ideal(aero_state_array(ichunk)%aero_state(icol,kk), n_part_ideal)
+          end do
+       end do
     end do
+
+    env_state = env_state_init
+
+    call add_hist_coord('npartmax',    n_part_max,    'NPARTMAX')
+    call add_hist_coord('na_spmax',    n_aero_sp_max,    'NAEROSPMAX')
+    call add_hist_coord('na_sp_partmax',    n_aero_sp_max,    'NAEROSPPARTMAX')
+    do i_spec = 1,aero_data_n_spec(aero_data)
+       call addfld( 'aero_particle_mass_'// trim(aero_data%name(i_spec)), &
+            (/'lev     ', 'npartmax' /), 'I', 'kg', 'constituent masses of each aerosol particle' )
     end do
-    end do
 
-  env_state = env_state_init
+    call addfld( 'number_concentration', (/'lev     ' /), 'I', 'm^{-3}', &
+         'number concentration per cell' )
+    call addfld( 'aero_num_conc', (/'lev     ', 'npartmax' /), 'I', 'm^{-3}', &
+         'number concentration for each particle' )
 
-  call add_hist_coord('npartmax',    n_part_max,    'NPARTMAX')
-  call add_hist_coord('na_spmax',    n_aero_sp_max,    'NAEROSPMAX')
-  call add_hist_coord('na_sp_partmax',    n_aero_sp_max,    'NAEROSPPARTMAX')
-  do i_spec = 1,aero_data_n_spec(aero_data)
-    call addfld( 'aero_particle_mass_'// trim(aero_data%name(i_spec)), &
-         (/'lev     ', 'npartmax' /), 'I', 'kg', 'constituent masses of each aerosol particle' )
-  end do
+    ! Get the number of modes
+    allocate(mam_num_names(nmodes))
+    allocate(mam_species_names(nmodes, nspec_max_modes))
+    call save_num_and_species_names(mam_num_names, mam_species_names)
 
-  call addfld( 'number_concentration', (/'lev     ' /), 'I', 'm^{-3}', &
-       'number concentration per cell' )
-  call addfld( 'aero_num_conc', (/'lev     ', 'npartmax' /), 'I', 'm^{-3}', &
-       'number concentration for each particle' )
-
-  ! Get the number of modes
-  allocate(mam_num_names(nmodes))
-  allocate(mam_species_names(nmodes, nspec_max_modes))
-  call save_num_and_species_names(mam_num_names,mam_species_names)
-
-  if (masterproc) then
-    write(102,*) '-----------------------------------------'
-    write(102,*) 'save_num_and_species_names'
-    do i_mode = 1, nmodes
-      write(102, "(A)", advance="no") "Mode " // trim(adjustl(mam_num_names(i_mode))) // ": "
-      call rad_cnst_get_info(0, i_mode, nspec=nspec)
-      do i_spec = 1, nspec
-        write(102, "(A)", advance="no") trim(adjustl(mam_species_names(i_mode, i_spec))) // " "
-      end do
-      write(102,*)
-    end do
-    write(102,*) '-----------------------------------------'
-  endif
-
-  ! Debugging
-  !if (masterproc) then
-  !   write(102,*) phys_state(begchunk)%q(1,pver,:)
-  !end if
+    if (masterproc) then
+       write(102,*) '-----------------------------------------'
+       write(102,*) 'save_num_and_species_names'
+       do i_mode = 1,nmodes
+          write(102, "(A)", advance="no") "Mode " // trim(adjustl(mam_num_names(i_mode))) // ": "
+          call rad_cnst_get_info(0, i_mode, nspec=nspec)
+          do i_spec = 1,nspec
+             write(102, "(A)", advance="no") trim(adjustl(mam_species_names(i_mode, i_spec))) // " "
+          end do
+          write(102,*)
+       end do
+       write(102,*) '-----------------------------------------'
+    end if
 
   end subroutine partmc_mam_inti
 
@@ -477,14 +467,13 @@ end subroutine compute_partmc_emission_inputs
     use cam_history,       only : outfld
     use constituents,     only: pcnst
 
-   use mo_chem_utls,        only : get_spc_ndx
-   use rad_constituents, only: rad_cnst_get_info, rad_cnst_get_mode_num_idx
-   use physconst,    only: spec_class_aerosol, spec_class_gas
-   use mo_gas_phase_chemdr, only : map2chm
-   use modal_aero_data, only: ntot_amode, modename_amode, sigmag_amode, &
+    use mo_chem_utls,        only : get_spc_ndx
+    use rad_constituents, only: rad_cnst_get_info, rad_cnst_get_mode_num_idx
+    use physconst,    only: spec_class_aerosol, spec_class_gas
+    use mo_gas_phase_chemdr, only : map2chm
+    use modal_aero_data, only: ntot_amode, modename_amode, sigmag_amode, &
        nspec_amode, numptr_amode, lmassptr_amode
 
-    implicit none
     type(physics_state), intent(inout):: state
     real(kind=dp),       intent(in) :: cflx(pcols,pcnst)              ! constituent surface flux (kg/m^2/s)
     real(kind=dp),            intent(in)    :: dt              ! time step
@@ -520,174 +509,171 @@ end subroutine compute_partmc_emission_inputs
     ! (phys_state%q is not populated until d_p_coupling runs before the first
     ! timestep, which is after partmc_mam_inti is called during phys_init.)
     if (.not. q_init_saved(lchnk)) then
-      allocate(aero_dist_init%mode(ntot_amode))
-      do i_mode = 1,ntot_amode
-       aero_dist_init%mode(i_mode)%name =  modename_amode(i_mode)
-       aero_dist_init%mode(i_mode)%type = AERO_MODE_TYPE_LOG_NORMAL
-       aero_dist_init%mode(i_mode)%source = aero_data_source_by_name(aero_data, &
-            aero_dist_init%mode(i_mode)%name)
-       weight_class_name = aero_dist_init%mode(i_mode)%name
-       aero_dist_init%mode(i_mode)%weight_class = aero_data_weight_class_by_name(aero_data, &
-            weight_class_name)
-       aero_dist_init%mode(i_mode)%log10_std_dev_radius = log10(sigmag_amode(i_mode))
-       allocate(aero_dist_init%mode(i_mode)%vol_frac(aero_data_n_spec(aero_data)))
-       allocate(aero_dist_init%mode(i_mode)%vol_frac_std(aero_data_n_spec(aero_data)))
-       aero_dist_init%mode(i_mode)%vol_frac_std = 0.0d0
-       aero_dist_init%mode(i_mode)%sample_radius = [ real(kind=dp) :: ]
-       aero_dist_init%mode(i_mode)%sample_num_conc = [ real(kind=dp) :: ]
+       allocate(aero_dist_init%mode(ntot_amode))
+       do i_mode = 1,ntot_amode
+          aero_dist_init%mode(i_mode)%name = modename_amode(i_mode)
+          aero_dist_init%mode(i_mode)%type = AERO_MODE_TYPE_LOG_NORMAL
+          aero_dist_init%mode(i_mode)%source = aero_data_source_by_name(aero_data, &
+               aero_dist_init%mode(i_mode)%name)
+          weight_class_name = aero_dist_init%mode(i_mode)%name
+          aero_dist_init%mode(i_mode)%weight_class = aero_data_weight_class_by_name(aero_data, &
+               weight_class_name)
+          aero_dist_init%mode(i_mode)%log10_std_dev_radius = log10(sigmag_amode(i_mode))
+          allocate(aero_dist_init%mode(i_mode)%vol_frac(aero_data_n_spec(aero_data)))
+          allocate(aero_dist_init%mode(i_mode)%vol_frac_std(aero_data_n_spec(aero_data)))
+          aero_dist_init%mode(i_mode)%vol_frac_std = 0.0d0
+          aero_dist_init%mode(i_mode)%sample_radius = [ real(kind=dp) :: ]
+          aero_dist_init%mode(i_mode)%sample_num_conc = [ real(kind=dp) :: ]
        end do
        do kk = 1,pver
-       do icol = 1,ncol
-          do i_mode = 1,ntot_amode
-          num_idx =  numptr_amode(i_mode)
-          idx_chm = map2chm(num_idx)
-          call rad_cnst_get_mode_num_idx(i_mode, num_idx)
-          aero_dist_init%mode(i_mode)%char_radius = 1.0d-8
-          aero_dist_init%mode(i_mode)%vol_frac = 1.0d0 / 20
-          aero_dist_init%mode(i_mode)%num_conc = 1e6
-          !if (masterproc)
-             !write(102,*) i_mode, num_idx, idx_chm, phys_state(ichunk)%q(icol,kk,idx_chm), &
-                  !phys_state(ichunk)%q(icol,kk,num_idx)
-          !endif
-          !aero_dist_init%mode(i_mode)%num_conc = phys_state(ichunk)%q(icol,kk,idx_chm)
+          do icol = 1,ncol
+             do i_mode = 1,ntot_amode
+                num_idx = numptr_amode(i_mode)
+                idx_chm = map2chm(num_idx)
+                call rad_cnst_get_mode_num_idx(i_mode, num_idx)
+                aero_dist_init%mode(i_mode)%char_radius = 1.0d-8
+                aero_dist_init%mode(i_mode)%vol_frac = 1.0d0 / 20
+                aero_dist_init%mode(i_mode)%num_conc = 1e6
+                !if (masterproc)
+                   !write(102,*) i_mode, num_idx, idx_chm, phys_state(ichunk)%q(icol,kk,idx_chm), &
+                        !phys_state(ichunk)%q(icol,kk,num_idx)
+                !endif
+                !aero_dist_init%mode(i_mode)%num_conc = phys_state(ichunk)%q(icol,kk,idx_chm)
+             end do
+             call aero_state_add_aero_dist_sample(aero_state_array(lchnk)%aero_state(icol,kk), &
+                  aero_data, aero_dist_init, 1d0, 1d0, 0d0, run_part_opt%allow_doubling, &
+                  run_part_opt%allow_halving)
           end do
-       call aero_state_add_aero_dist_sample(aero_state_array(lchnk)%aero_state(icol,kk), &
-            aero_data, aero_dist_init, 1d0, 1d0, 0d0, run_part_opt%allow_doubling, &
-            run_part_opt%allow_halving)
-       end do
        end do
        q_init_saved(lchnk) = .true.
     end if
 
     ! Output arrays
-    aero_particle_mass_out(:,:,:,:)=-1000d0
+    aero_particle_mass_out(:,:,:,:)= -1000d0
     number_conc_out(:,:) = 0d0
     aero_num_conc_out(:,:,:) = 0d0
 
     if (masterproc) then
-         write(102,*) '-----------------------------------------'
-         write(102,*) 'Time step and Time max'
-         write(102,*) 'run_part_opt%del_t: ', run_part_opt%del_t
-         write(102,*) 'run_part_opt%t_max: ', run_part_opt%t_max
-         write(102,*) '-----------------------------------------'
-    endif
+       write(102,*) '-----------------------------------------'
+       write(102,*) 'Time step and Time max'
+       write(102,*) 'run_part_opt%del_t: ', run_part_opt%del_t
+       write(102,*) 'run_part_opt%t_max: ', run_part_opt%t_max
+       write(102,*) '-----------------------------------------'
+    end if
 
     ! FIXME: What time information does PartMC need here?
-    env_state%start_time=0
-    env_state%start_day=0
-    env_state%elapsed_time=0d0
+    env_state%start_time = 0d0
+    env_state%start_day = 0d0
+    env_state%elapsed_time = 0d0
 
     ! emission inputs
-    geom_mean_diameter(:,:)=0
-    num_fluxes(:,:)=0
+    geom_mean_diameter(:,:) = 0d0
+    num_fluxes(:,:) = 0d0
     call compute_partmc_emission_inputs(cflx, ncol, geom_mean_diameter, &
          sigma_mam, num_fluxes, volume_fractions)
 
     do kk = 1,pver
-      do icol = 1, ncol
-        ! Copy E3SM values to PartMC
-        do i = 1,gas_data_n_spec(gas_data) !n_species
-          ! TODO: Confirm units: PartMC is ppb. E3SM is vmr with units of mol/mol ?
-          gas_state%mix_rat(i) = state%q(icol,kk,i) * 1d9
-        end do ! species
+       do icol = 1,ncol
+          ! Copy E3SM values to PartMC
+          do i = 1,gas_data_n_spec(gas_data) !n_species
+             ! TODO: Confirm units: PartMC is ppb. E3SM is vmr with units of mol/mol ?
+             gas_state%mix_rat(i) = state%q(icol,kk,i) * 1d9
+          end do ! species
 
-        ! Debugging
-        !if (masterproc) then
-        !   write(102,*) state%q(icol,kk,:)
-        !end if
+          ! Debugging
+          !if (masterproc) then
+          !   write(102,*) state%q(icol,kk,:)
+          !end if
 
-        ! FIXME: Think about how to best do this scenario/env_state.
-        ! scenario%temp(:)  = state%t(icol,kk)
-        ! scenario%pressure = state%pmid(icol,kk)
-        ! scenario%height(:) = state%zm(icol,kk)
-        ! FIXME: we need to compute rel_humid
-        !   See relhum array calculation in mo_gas_phase_chemdr.F90
-        !!      call qsat(tfld(:ncol,:), pmid(:ncol,:), satv, satq)
-        !!      relhum(:,k) = .622_r8 * h2ovmr(:,k) / satq(:,k)
-        !!      relhum(:,k) = max( 0._r8,min( 1._r8,relhum(:,k) ) )
-        env_state%rel_humid = 0.95
+          ! FIXME: Think about how to best do this scenario/env_state.
+          ! scenario%temp(:)  = state%t(icol,kk)
+          ! scenario%pressure = state%pmid(icol,kk)
+          ! scenario%height(:) = state%zm(icol,kk)
+          ! FIXME: we need to compute rel_humid
+          !   See relhum array calculation in mo_gas_phase_chemdr.F90
+          !!      call qsat(tfld(:ncol,:), pmid(:ncol,:), satv, satq)
+          !!      relhum(:,k) = .622_r8 * h2ovmr(:,k) / satq(:,k)
+          !!      relhum(:,k) = max( 0._r8,min( 1._r8,relhum(:,k) ) )
+          env_state%rel_humid = 0.95d0
 
-        env_state%latitude = state%lat(icol)
-        env_state%longitude = state%lon(icol)
-        env_state%altitude = state%zm(icol,kk) ! Geopotential height (m)
+          env_state%latitude = state%lat(icol)
+          env_state%longitude = state%lon(icol)
+          env_state%altitude = state%zm(icol,kk) ! Geopotential height (m)
 
-        env_state%temp = state%t(icol,kk) ! Midpoint temperature (K)
-        env_state%pressure = state%pmid(icol,kk) ! Midpoint pressure (Pa)
-        ! FIXME: zm is midpoint geopotential height
-        !        zi  is interface geopotential height
-        !        we really want geometric height
-        env_state%height = state%zi(icol,kk) - state%zi(icol,kk+1)
-        ! FIXME: should compute this at some point
-        !        see zenith() code in mo_gas_phase_chemdr.F90
-        env_state%solar_zenith_angle = 0d0
+          env_state%temp = state%t(icol,kk) ! Midpoint temperature (K)
+          env_state%pressure = state%pmid(icol,kk) ! Midpoint pressure (Pa)
+          ! FIXME: zm is midpoint geopotential height
+          !        zi  is interface geopotential height
+          !        we really want geometric height
+          env_state%height = state%zi(icol,kk) - state%zi(icol,kk+1)
+          ! FIXME: should compute this at some point
+          !        see zenith() code in mo_gas_phase_chemdr.F90
+          env_state%solar_zenith_angle = 0d0
 
-        ! For now, lets just try coagulation + emission.
-        ! We probably want a custom code here anyway to have better control:
-        !    - We might need a custom time stepper for efficiency in TChem solving
-        !    - E3SM probably will control emissions
-        !    - We have to remove dilution
-        !    - It appears we have no (stored) time varying scenario data.
-        n_coag = 0
-        n_samp = 0
-        n_emit = 0
-        call partmc_interface_e3sm_emissions(state, emissions, &
-           geom_mean_diameter(icol,:), sigma_mam, num_fluxes(icol,:), volume_fractions(icol, : , :))
-        if (masterproc) then
-           if (icol == 1) then
-              write(102,*) '-----------------------------------------'
-              write(102,*) 'grid cell | temperature | pressure | box height | altitude'
-              write(102,*) kk, env_state%temp, env_state%pressure,env_state%height,  env_state%altitude
-              write(102,*) '-----------------------------------------'
-           end if
-           if (kk == pver) then
-              write(102,*) '-----------------------------------------'
-              write(102,*) 'i_mode | radius | log10sigma | number flux'
-              do i_mode = 1,n_emit_mode
-                 write(102,*) i_mode, emissions%mode(i_mode)%char_radius, &
-                         emissions%mode(i_mode)%log10_std_dev_radius, &
-                         emissions%mode(i_mode)%num_conc
-              end do
-              write(102,*) '-----------------------------------------'
-           end if
-        end if 
+          ! For now, lets just try coagulation + emission.
+          ! We probably want a custom code here anyway to have better control:
+          !    - We might need a custom time stepper for efficiency in TChem solving
+          !    - E3SM probably will control emissions
+          !    - We have to remove dilution
+          !    - It appears we have no (stored) time varying scenario data.
+          n_coag = 0
+          n_samp = 0
+          n_emit = 0
+          call partmc_interface_e3sm_emissions(state, emissions, &
+               geom_mean_diameter(icol,:), sigma_mam, num_fluxes(icol,:), volume_fractions(icol,:,:))
+          if (masterproc) then
+             if (icol == 1) then
+                write(102,*) '-----------------------------------------'
+                write(102,*) 'grid cell | temperature | pressure | box height | altitude'
+                write(102,*) kk, env_state%temp, env_state%pressure, env_state%height, env_state%altitude
+                write(102,*) '-----------------------------------------'
+             end if
+             if (kk == pver) then
+                write(102,*) '-----------------------------------------'
+                write(102,*) 'i_mode | radius | log10sigma | number flux'
+                do i_mode = 1,n_emit_mode
+                   write(102,*) i_mode, emissions%mode(i_mode)%char_radius, &
+                        emissions%mode(i_mode)%log10_std_dev_radius, &
+                        emissions%mode(i_mode)%num_conc
+                end do
+                write(102,*) '-----------------------------------------'
+             end if
+          end if
 
-        do i_time = 1,n_time
+          do i_time = 1,n_time
 
-           ! Aerosol emissions
-           if (kk == pver) then
-              emission_rate_scale = 1.0d0
-              characteristic_factor = 3600.0d0 / run_part_opt%del_t
-              p = emission_rate_scale * run_part_opt%del_t / env_state%height
-              call aero_state_add_aero_dist_sample(aero_state_array(lchnk)%aero_state(icol,kk), &
-                   aero_data,  emissions, p, characteristic_factor, env_state%elapsed_time, &
-                   run_part_opt%allow_doubling, run_part_opt%allow_halving, n_emit)
-           end if
+             ! Aerosol emissions
+             if (kk == pver) then
+                emission_rate_scale = 1.0d0
+                characteristic_factor = 3600.0d0 / run_part_opt%del_t
+                p = emission_rate_scale * run_part_opt%del_t / env_state%height
+                call aero_state_add_aero_dist_sample(aero_state_array(lchnk)%aero_state(icol,kk), &
+                     aero_data, emissions, p, characteristic_factor, env_state%elapsed_time, &
+                     run_part_opt%allow_doubling, run_part_opt%allow_halving, n_emit)
+             end if
 
-           ! Coagulation
-           if (run_part_opt%do_coagulation) then
-              call mc_coag(run_part_opt%coag_kernel_type, env_state, aero_data, &
-                   aero_state_array(lchnk)%aero_state(icol,kk), run_part_opt%del_t, &
-                   n_samp, n_coag)
-           end if
+             ! Coagulation
+             if (run_part_opt%do_coagulation) then
+                call mc_coag(run_part_opt%coag_kernel_type, env_state, aero_data, &
+                     aero_state_array(lchnk)%aero_state(icol,kk), run_part_opt%del_t, &
+                     n_samp, n_coag)
+             end if
 
-           ! Rebalance
-           call aero_state_rebalance(aero_state_array(lchnk)%aero_state(icol,kk), aero_data, &
-                run_part_opt%allow_doubling, &
-                run_part_opt%allow_halving, initial_state_warning=.false.)
+             ! Rebalance
+             call aero_state_rebalance(aero_state_array(lchnk)%aero_state(icol,kk), aero_data, &
+                  run_part_opt%allow_doubling, &
+                  run_part_opt%allow_halving, initial_state_warning=.false.)
 
-        end do
-        call write_nc_aero_state(aero_state_array(lchnk)%aero_state(icol,kk), &
-             aero_particle_mass_out, &
-                            aero_num_conc_out, &
-                            number_conc_out, &
-                            icol, kk)
-      end do ! icol
+          end do
+          call write_nc_aero_state(aero_state_array(lchnk)%aero_state(icol,kk), &
+               aero_particle_mass_out, aero_num_conc_out, number_conc_out, icol, kk)
+       end do ! icol
     end do ! kk
 
-   ! Output to E3SM
+    ! Output to E3SM
     do i = 1,aero_data_n_spec(aero_data)
-        call outfld( 'aero_particle_mass_'// trim(aero_data%name(i)), &
-             aero_particle_mass_out(:ncol, :, :, i), ncol, lchnk )
+       call outfld( 'aero_particle_mass_'// trim(aero_data%name(i)), &
+            aero_particle_mass_out(:ncol, :, :, i), ncol, lchnk )
     end do
 
     call outfld( 'number_concentration', number_conc_out(:ncol, :), ncol, lchnk )
@@ -702,7 +688,6 @@ end subroutine compute_partmc_emission_inputs
                               number_conc_out, &
                               icol, kk)
 
-  implicit none
   !> aero_state to write.
   integer :: n_part, i_part, n_sp_aero
   type(aero_state_t), intent(in) :: aero_state
@@ -746,7 +731,6 @@ end subroutine compute_partmc_emission_inputs
     use physics_types,    only : physics_state
     use rad_constituents, only: rad_cnst_get_info
 
-    implicit none
     type(physics_state), intent(in):: state
     type(aero_dist_t), intent(inout) :: emissions
 
@@ -807,12 +791,6 @@ end subroutine compute_partmc_emission_inputs
     integer :: m, l
     integer :: n_spec, n_modes
     real(kind=dp) :: density, hygro
-    character(AERO_NAME_LEN), parameter, dimension(20) :: &
-         mosaic_spec_name = [ &
-         "SO4   ", "NO3   ", "Cl    ", "NH4   ", "MSA   ", "ARO1  ", &
-         "ARO2  ", "ALK1  ", "OLE1  ", "API1  ", "API2  ", "LIM1  ", &
-         "LIM2  ", "CO3   ", "Na    ", "Ca    ", "OIN   ", "OC    ", &
-         "BC    ", "H2O   "]
     character(len=20):: aername
 
     integer :: i, j, n, unique_count, total_mam_vars, i_name
@@ -839,7 +817,7 @@ end subroutine compute_partmc_emission_inputs
                aername = aername, &
                density_aer = density, &
                hygro_aer   = hygro)
-           write(102,*) m,l, trim(aername),density, hygro, lspectype_amode(l,m)
+           write(102,*) m,l, trim(aername), density, hygro, lspectype_amode(l,m)
          end do
       end do
       do l=1,ntot_aspectype

--- a/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
+++ b/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
@@ -37,7 +37,7 @@ module mo_partmc_interface
     integer :: i_repeat, i_group
     integer :: rand_init
     ! Maximum number of computational particles. Used for output.
-    integer, parameter, public :: n_part_max = 100
+    integer, parameter, public :: n_part_max = 500
     ! Maximum number of aerosol species. Used for output.
     integer, parameter, public :: n_aero_sp_max = 25
 
@@ -310,7 +310,7 @@ end subroutine compute_partmc_emission_inputs
     character(len=AERO_MODE_NAME_LEN) :: mode_name
     character(len=SPEC_LINE_MAX_VAR_LEN) :: weight_class_name
 
-    n_part_ideal = 50.0d0
+    n_part_ideal = 250.0d0
 
     env_state_init%elapsed_time = 0d0
     
@@ -1517,14 +1517,23 @@ end subroutine compute_partmc_emission_inputs
 
   end subroutine compute_partmc_emission_inputs_sector
 
-  ! Stub: per-step inputs for the natural-source pseudo-modes (SEASALT, DUST).
+  ! Per-step inputs for the natural-source pseudo-modes (SEASALT, DUST).
   !
-  ! Real implementation (to fill in):
   !   * Seasalt: fi(:ncol,:nsections) = sslt_sections::fluxes(cam_in%sst, u10cubed, ncol)
   !              sample_num_conc(icol, seasalt_mode_idx, ibin) =
   !                fi(icol, ibin) * cam_in%ocnfrac(icol) * seasalt_emis_scale
   !   * Dust:    derive per-bin number from cam_in%dstflx + soil_erodibility +
   !              dust_emis_sclfctr + dust_dmt_vwr (mass→number conversion).
+  !
+  ! TODO:The dust implementation is a first pass and needs improvement.
+  ! The bins are simply too large. The binned approach can be quite attractive when
+  ! we have many bins to resolve the size distribution in a way that we do not need to assume a
+  ! log-normal. For PartMC, we sample a diameters between bin edges uniformally.
+  ! This assumption is not ideal when the bins are large. This likely means that the smaller
+  ! particles will be oversampled in the smallest bin and the larger particles will be
+  ! oversampled in the last bin.
+  ! We may actually be best off with a log-normal approach for dust, or consider adding 
+  ! more bins to properly resolve the size and mass distribution.
   subroutine compute_partmc_natural_emission_inputs(state, cam_in, ncol, &
        u10cubed, sample_num_conc)
     use physics_types, only : physics_state
@@ -1532,6 +1541,11 @@ end subroutine compute_partmc_emission_inputs
     use ppgrid,        only : pver
     use sslt_sections, only : nsections, fluxes
     use aero_model,    only : seasalt_emis_scale
+    use dust_model,    only : dust_nbin, dust_emis_sclfctr, dust_dmt_vwr
+    use shr_dust_mod,  only : dust_emis_scheme
+    use soil_erod_mod, only : soil_erodibility, soil_erod_fact
+    use mo_constants,  only : dust_density
+    use physconst,     only : pi
 
     ! Current physics state.
     type(physics_state), intent(in)  :: state
@@ -1547,12 +1561,16 @@ end subroutine compute_partmc_emission_inputs
     real(kind=dp), intent(out) :: sample_num_conc(:,:,:)
 
     real(kind=dp), parameter :: z0 = 1.0d-4 ! ocean roughness length (m); matches aero_model.F90
+    real(kind=dp), parameter :: soil_erod_threshold = 0.1d0  ! matches dust_emis
     real(kind=dp) :: u10(pcols)
     real(kind=dp) :: fi_seasalt(pcols, nsections)
+    real(kind=dp) :: soil_erod_val, mass_flux, x_mton
+    integer :: lchnk
     integer :: icol, ibin, i_mode
 
     sample_num_conc(:,:,:) = 0.0d0
     u10cubed(:) = 0.0d0
+    lchnk = state%lchnk
 
     ! Wind at 10 m, raised to the 3.41 power per Gong et al. (1997).
     ! Same code path as aero_model.F90:2880-2887.
@@ -1596,8 +1614,53 @@ end subroutine compute_partmc_emission_inputs
              write(102,*) '-----------------------------------------'
           end if
        end if
-       ! TODO: 'emit_DUST' branch — derive per-bin number from cam_in%dstflx,
-       ! soil_erodibility, dust_emis_sclfctr, and dust_dmt_vwr.
+       if ( trim(sector_modes(i_mode)%name) == 'emit_DUST' ) then
+          ! Per-column, per-bin dust mass and number flux. Direct port of the
+          ! per-column logic in dust_model.F90:dust_emis (lines 143-171).
+          ! Mass flux uses CLM-supplied dust_flux_in (in cam_in%dstflx),
+          ! rescaled by dust_emis_sclfctr per bin and weighted by soil
+          ! erodibility. Number is derived via x_mton = 6/(pi*rho*Dvwr^3).
+          !
+          ! NOTE: aero_model.F90:2851-2868 caps total dust mass flux against
+          ! dstemislimit and rescales the per-bin distribution if the cap is
+          ! hit. That cap is not applied here — for tightly comparable totals
+          ! against MAM's cflx it should be ported. Cap rarely triggers in
+          ! practice, so deferred for now.
+          do icol = 1, ncol
+             soil_erod_val = soil_erodibility(icol, lchnk)
+             if ( dust_emis_scheme == 2 ) soil_erod_val = 1.0d0
+             if ( soil_erod_val < soil_erod_threshold ) soil_erod_val = 0.0d0
+
+             do ibin = 1, dust_nbin
+                mass_flux = sum(-cam_in%dstflx(icol, :)) * 0.73d0 / 0.87d0 &
+                     * dust_emis_sclfctr(ibin) * soil_erod_val / soil_erod_fact * 1.15d0
+                x_mton = 6.0d0 / (pi * dust_density * dust_dmt_vwr(ibin)**3)
+                sample_num_conc(icol, i_mode, ibin) = mass_flux * x_mton
+             end do
+          end do
+
+          if ( masterproc ) then
+             write(102,*) '-----------------------------------------'
+             write(102,*) 'Dust sample_num_conc (i_mode=', i_mode, ')'
+             write(102,*) 'soil_erod_fact (from soil_erod_mod) = ', soil_erod_fact
+             write(102,*) 'dust_emis_scheme (from shr_dust_mod) = ', dust_emis_scheme
+             write(102,*) 'icol | soil_erod | dst_total | total num flux (m^-2 s^-1)'
+             do icol = 1, ncol
+                soil_erod_val = soil_erodibility(icol, lchnk)
+                if ( dust_emis_scheme == 2 ) soil_erod_val = 1.0d0
+                if ( soil_erod_val < soil_erod_threshold ) soil_erod_val = 0.0d0
+                write(102,*) icol, soil_erod_val, sum(-cam_in%dstflx(icol, :)), &
+                     sum(sample_num_conc(icol, i_mode, 1:dust_nbin))
+             end do
+             write(102,*) 'Per-bin breakdown (icol = 1):'
+             write(102,*) 'ibin | radius edge low (m) | dmt_vwr (m) | num_conc (m^-2 s^-1)'
+             do ibin = 1, dust_nbin
+                write(102,*) ibin, sector_modes(i_mode)%sample_radius(ibin), &
+                     dust_dmt_vwr(ibin), sample_num_conc(1, i_mode, ibin)
+             end do
+             write(102,*) '-----------------------------------------'
+          end if
+       end if
 
     end do
 

--- a/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
+++ b/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
@@ -466,9 +466,8 @@ end subroutine compute_partmc_emission_inputs
     use physics_types,    only : physics_state
     use cam_history,       only : outfld
     use constituents,     only: pcnst
-
     use mo_chem_utls,        only : get_spc_ndx
-    use rad_constituents, only: rad_cnst_get_info, rad_cnst_get_mode_num_idx
+    use rad_constituents, only: rad_cnst_get_info, rad_cnst_get_mode_num_idx, rad_cnst_get_mam_mmr_idx
     use physconst,    only: spec_class_aerosol, spec_class_gas
     use mo_gas_phase_chemdr, only : map2chm
     use modal_aero_data, only: ntot_amode, modename_amode, sigmag_amode, &
@@ -494,7 +493,10 @@ end subroutine compute_partmc_emission_inputs
     type(aero_dist_t) :: emissions
     type(aero_dist_t) :: aero_dist_init
     character(len=SPEC_LINE_MAX_VAR_LEN) :: weight_class_name
-    integer :: num_idx, idx_chm
+    integer :: num_idx, idx_chm, spec_idx
+    integer :: nspec, i_spec, n
+    real(kind=dp), parameter :: third = 1.0 / 3.0
+    real(kind=dp) :: dryvol, dumfac, dummwdens, dgncur_a, num_a
 
     !FIXME: we must pass a delta time factor
     n_time = 30
@@ -505,7 +507,7 @@ end subroutine compute_partmc_emission_inputs
     lchnk = state%lchnk
     ncol  = state%ncol
 
-    ! Capture initial q on first invocation for this chunk.
+    ! Capture initial condition on first invocation for this chunk.
     ! (phys_state%q is not populated until d_p_coupling runs before the first
     ! timestep, which is after partmc_mam_inti is called during phys_init.)
     if (.not. q_init_saved(lchnk)) then
@@ -528,23 +530,41 @@ end subroutine compute_partmc_emission_inputs
        do kk = 1,pver
           do icol = 1,ncol
              do i_mode = 1,ntot_amode
+                ! Set number concentration of the mode
                 num_idx = numptr_amode(i_mode)
                 idx_chm = map2chm(num_idx)
                 call rad_cnst_get_mode_num_idx(i_mode, num_idx)
-                aero_dist_init%mode(i_mode)%char_radius = 1.0d-8
-                aero_dist_init%mode(i_mode)%vol_frac = 1.0d0 / 20
-                aero_dist_init%mode(i_mode)%num_conc = 1e6
+                aero_dist_init%mode(i_mode)%num_conc = state%q(icol,kk,num_idx)
+                aero_dist_init%mode(i_mode)%vol_frac = 0.0d0
+                ! Set volume fraction of the mode
+                call rad_cnst_get_info(0, i_mode, nspec=nspec)
+                dryvol = 0.d0
+                do i_spec = 1, nspec
+                    call rad_cnst_get_mam_mmr_idx(i_mode, i_spec, spec_idx)
+                    idx_chm = map2chm(spec_idx)
+                    ! Convert from mass mixing ratio to volume fraction using density
+                    aero_dist_init%mode(i_mode)%vol_frac(spec_idx) = &
+                        state%q(icol,kk,idx_chm) / aero_data%density(spec_idx)
+                    ! Compute dry volume of mode for diameter calculation
+                    dummwdens = 1.0d0 / aero_data%density(spec_idx)
+                    dryvol = dryvol + max(0.0d0, state%q(icol,kk,idx_chm))*dummwdens
+                end do
+                
+                ! Calculate geometric median diameter
+                dumfac = exp(4.5d0*log(sigmag_amode(i_mode))**2)*const%pi/6.0d0
+                dgncur_a = (dryvol/(dumfac*num_a))**third
+                aero_dist_init%mode(i_mode)%char_radius = dgncur_a / 2.0d0
                 !if (masterproc)
                    !write(102,*) i_mode, num_idx, idx_chm, phys_state(ichunk)%q(icol,kk,idx_chm), &
                         !phys_state(ichunk)%q(icol,kk,num_idx)
                 !endif
-                !aero_dist_init%mode(i_mode)%num_conc = phys_state(ichunk)%q(icol,kk,idx_chm)
              end do
              call aero_state_add_aero_dist_sample(aero_state_array(lchnk)%aero_state(icol,kk), &
                   aero_data, aero_dist_init, 1d0, 1d0, 0d0, run_part_opt%allow_doubling, &
                   run_part_opt%allow_halving)
           end do
        end do
+       ! Set the flag to indicate that initial values have been set for this chunk
        q_init_saved(lchnk) = .true.
     end if
 
@@ -566,7 +586,7 @@ end subroutine compute_partmc_emission_inputs
     env_state%start_day = 0d0
     env_state%elapsed_time = 0d0
 
-    ! emission inputs
+    ! Emission inputs from E3SM
     geom_mean_diameter(:,:) = 0d0
     num_fluxes(:,:) = 0d0
     call compute_partmc_emission_inputs(cflx, ncol, geom_mean_diameter, &
@@ -619,8 +639,10 @@ end subroutine compute_partmc_emission_inputs
           n_coag = 0
           n_samp = 0
           n_emit = 0
+          ! Set the PartMC data structure for aerosol emissions
           call partmc_interface_e3sm_emissions(state, emissions, &
                geom_mean_diameter(icol,:), sigma_mam, num_fluxes(icol,:), volume_fractions(icol,:,:))
+
           if (masterproc) then
              if (icol == 1) then
                 write(102,*) '-----------------------------------------'
@@ -640,6 +662,7 @@ end subroutine compute_partmc_emission_inputs
              end if
           end if
 
+          ! Time stepping for PartMC processes
           do i_time = 1,n_time
 
              ! Aerosol emissions

--- a/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
+++ b/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
@@ -650,7 +650,7 @@ end subroutine compute_partmc_emission_inputs
     integer :: lchnk, ncol
     type(aero_dist_t) :: aero_dist_init
     character(len=SPEC_LINE_MAX_VAR_LEN) :: weight_class_name
-    integer :: i_mode, i_spec, kk, icol, ll
+    integer :: i_mode, i_spec, kk, icol, pmc_aero_idx
     integer :: num_idx, idx_chm, spec_idx, nspec
     real(kind=dp) :: dryvol, dumfac, dummwdens, dgnum_dry, num_a
 
@@ -687,12 +687,12 @@ end subroutine compute_partmc_emission_inputs
              do i_spec = 1,nspec
                 call rad_cnst_get_mam_mmr_idx(i_mode, i_spec, spec_idx)
                 idx_chm = map2chm(spec_idx)
-                ll = mam_spec_to_partmc_spec(i_mode, i_spec)
+                pmc_aero_idx = mam_spec_to_partmc_spec(i_mode, i_spec)
                 ! Convert from mass mixing ratio to volume fraction using density
-                aero_dist_init%mode(i_mode)%vol_frac(ll) = &
-                     state%q(icol,kk,idx_chm) / aero_data%density(ll)
+                aero_dist_init%mode(i_mode)%vol_frac(pmc_aero_idx) = &
+                     state%q(icol,kk,idx_chm) / aero_data%density(pmc_aero_idx)
                 ! Compute dry volume of mode for diameter calculation
-                dummwdens = 1.0d0 / aero_data%density(ll)
+                dummwdens = 1.0d0 / aero_data%density(pmc_aero_idx)
                 dryvol = dryvol + max(0.0d0, state%q(icol,kk,idx_chm))*dummwdens
              end do
              ! Normalize volume fractions
@@ -779,20 +779,21 @@ end subroutine compute_partmc_emission_inputs
 
   end subroutine write_nc_aero_state
 
+  ! Maps E3SM aerosol emissions to the PartMC emissions data structure.
   subroutine partmc_interface_e3sm_emissions(state, emissions, geom_mean_diam, &
       sigma, num_fluxes, vol_frac)
     use physics_types,    only : physics_state
     use rad_constituents, only: rad_cnst_get_info
 
     type(physics_state), intent(in):: state
+    ! Emissions data structure to pass to PartMC.
     type(aero_dist_t), intent(inout) :: emissions
 
     real(kind=dp), intent(in) ::  geom_mean_diam(nmodes)
     real(kind=dp), intent(in) ::  sigma(nmodes)
     real(kind=dp), intent(in) ::  num_fluxes(nmodes)
     real(kind=dp), intent(in) ::  vol_frac(nmodes, nspec_max_modes)
-
-    integer :: i_mode, i_spec, n_spec_emit, ll
+    integer :: i_mode, i_spec, n_spec_emit, pmc_spec_idx
     character(len=AERO_MODE_NAME_LEN) :: mode_name
     character(len=SPEC_LINE_MAX_VAR_LEN) :: weight_class_name
 
@@ -814,14 +815,13 @@ end subroutine compute_partmc_emission_inputs
        allocate(emissions%mode(i_mode)%vol_frac(aero_data_n_spec(aero_data)))
        allocate(emissions%mode(i_mode)%vol_frac_std(aero_data_n_spec(aero_data)))
        emissions%mode(i_mode)%vol_frac = 0.0d0
-       ! number of species in this mode
+       ! Number of emitted species in this mode
        call rad_cnst_get_info(list_idx, i_mode, nspec=n_spec_emit)
-       do i_spec =1,n_spec_emit
-          ll = mam_spec_to_partmc_spec(i_mode,i_spec)
-          emissions%mode(i_mode)%vol_frac(ll) = vol_frac(i_mode,i_spec) 
+       do i_spec = 1,n_spec_emit
+          pmc_spec_idx = mam_spec_to_partmc_spec(i_mode, i_spec)
+          emissions%mode(i_mode)%vol_frac(pmc_spec_idx) = vol_frac(i_mode, i_spec)
        end do
        emissions%mode(i_mode)%vol_frac_std = 0.0d0
-
        emissions%mode(i_mode)%sample_radius = [ real(kind=dp) :: ]
        emissions%mode(i_mode)%sample_num_conc = [ real(kind=dp) :: ]
     end do
@@ -830,7 +830,6 @@ end subroutine compute_partmc_emission_inputs
 
   ! Initializes aero_data from E3SM aerosol scheme.
   subroutine aero_data_init(aero_data)
-
     use rad_constituents, only: rad_cnst_get_info, rad_cnst_get_aer_props
     use modal_aero_data, only: &
         lspectype_amode, ntot_aspectype, specname_amode, specdens_amode, specmw_amode, spechygro
@@ -840,17 +839,17 @@ end subroutine compute_partmc_emission_inputs
 
     integer :: n_aero_spec
     integer :: n_swbands
-    integer :: i_spec, i_mode
+    integer :: i_spec
     integer :: m, l
     integer :: n_spec, n_modes
     real(kind=dp) :: density, hygro
     character(len=20):: aername
-
     integer :: i, j, n, unique_count, total_mam_vars, i_name
     logical :: is_unique
     character(len=20), dimension(:), allocatable :: input_array, unique_array
     real(kind=dp), dimension(:), allocatable :: density_array, kappa_array, mw_array
     real(kind=dp), dimension(:), allocatable :: unique_density_array, unique_kappa_array, unique_mw_array
+
     ! Notes:
     !   ntot_aspectype = overall number of aerosol chemical species defined (over all modes)
     !   specdens_amode(l) = dry density (kg/m^3) of aerosol chemical species type l

--- a/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
+++ b/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
@@ -47,6 +47,7 @@ module mo_partmc_interface
     ! mam information
     character(len=256), allocatable :: mam_num_names(:)
     character(len=256), allocatable :: mam_species_names(:,:)
+    integer, allocatable :: mam_spec_to_partmc_spec(:,:)
 contains
 !-----------------------------------------------------------------------
   subroutine compute_nspec_max(nspec_max)
@@ -87,7 +88,7 @@ subroutine save_num_and_species_names(num_names, species_names)
   character(len=256) :: num_name         ! Temporary variable for number flux name
 
   ! Loop over modes to retrieve names
-  do n = 1, nmodes
+  do n = 1,nmodes
     ! Get the number flux index for the mode
     call rad_cnst_get_mode_num_idx(n, num_idx)
 
@@ -401,6 +402,8 @@ end subroutine compute_partmc_emission_inputs
   end if
 
   ! Initialization of aerosol data
+  call rad_cnst_get_info(0, nmodes=nmodes)
+  call compute_nspec_max(nspec_max_modes)
   call aero_data_init(aero_data)
 
   call spec_file_read_run_part_eam(run_part_opt, &
@@ -463,11 +466,12 @@ end subroutine compute_partmc_emission_inputs
        'number concentration for each particle' )
 
   ! Get the number of modes
-  call rad_cnst_get_info(0, nmodes=nmodes)
-  call compute_nspec_max(nspec_max_modes)
+!  call rad_cnst_get_info(0, nmodes=nmodes)
+!  call compute_nspec_max(nspec_max_modes)
   allocate(mam_num_names(nmodes))
   allocate(mam_species_names(nmodes, nspec_max_modes))
   call save_num_and_species_names(mam_num_names,mam_species_names)
+
   if (masterproc) then
     write(102,*) '-----------------------------------------'
     write(102,*) 'save_num_and_species_names'
@@ -559,6 +563,9 @@ end subroutine compute_partmc_emission_inputs
         ! scenario%height(:) = state%zm(icol,kk)
         ! FIXME: we need to compute rel_humid
         !   See relhum array calculation in mo_gas_phase_chemdr.F90
+        !!      call qsat(tfld(:ncol,:), pmid(:ncol,:), satv, satq)
+        !!      relhum(:,k) = .622_r8 * h2ovmr(:,k) / satq(:,k)
+        !!      relhum(:,k) = max( 0._r8,min( 1._r8,relhum(:,k) ) )
         env_state%rel_humid = 0.95
 
         env_state%latitude = state%lat(icol)
@@ -715,7 +722,7 @@ end subroutine compute_partmc_emission_inputs
     real(kind=dp), intent(in) ::  num_fluxes(nmodes)
     real(kind=dp), intent(in) ::  vol_frac(nmodes, nspec_max_modes)
 
-    integer :: i_mode
+    integer :: i_mode, i_spec, n_spec_emit
     character(len=AERO_MODE_NAME_LEN) :: mode_name
     character(len=SPEC_LINE_MAX_VAR_LEN) :: weight_class_name
 
@@ -736,7 +743,12 @@ end subroutine compute_partmc_emission_inputs
        emissions%mode(i_mode)%num_conc = num_fluxes(i_mode)
        allocate(emissions%mode(i_mode)%vol_frac(aero_data_n_spec(aero_data)))
        allocate(emissions%mode(i_mode)%vol_frac_std(aero_data_n_spec(aero_data)))
-       emissions%mode(i_mode)%vol_frac = 1.0d0 / 20
+       emissions%mode(i_mode)%vol_frac = 0.0d0
+       ! number of species in this mode
+       n_spec_emit = 1
+       do i_spec =1,n_spec_emit
+          emissions%mode(i_mode)%vol_frac(i_spec) = 1.0d0
+       end do
        emissions%mode(i_mode)%vol_frac_std = 0.0d0
 
        emissions%mode(i_mode)%sample_radius = [ real(kind=dp) :: ]
@@ -750,18 +762,18 @@ end subroutine compute_partmc_emission_inputs
 
     use rad_constituents, only: rad_cnst_get_info, rad_cnst_get_aer_props
     use modal_aero_data, only: &
-        lspectype_amode
+        lspectype_amode, ntot_aspectype, specname_amode, specdens_amode, specmw_amode, spechygro
 
     !> Aerosol data.
     type(aero_data_t), intent(inout) :: aero_data
 
-    integer, parameter :: n_aero_spec = 20
+    integer :: n_aero_spec
     integer :: n_swbands
     integer :: i_spec, i_mode
     integer :: m, l
-    integer :: n_spec
+    integer :: n_spec, n_modes
     real(kind=dp) :: density, hygro
-    character(AERO_NAME_LEN), parameter, dimension(n_aero_spec) :: &
+    character(AERO_NAME_LEN), parameter, dimension(20) :: &
          mosaic_spec_name = [ &
          "SO4   ", "NO3   ", "Cl    ", "NH4   ", "MSA   ", "ARO1  ", &
          "ARO2  ", "ALK1  ", "OLE1  ", "API1  ", "API2  ", "LIM1  ", &
@@ -769,11 +781,26 @@ end subroutine compute_partmc_emission_inputs
          "BC    ", "H2O   "]
     character(len=20):: aername
 
+    integer :: i, j, n, unique_count, total_mam_vars, i_name
+    logical :: is_unique
+    character(len=20), dimension(:), allocatable :: input_array, unique_array
+    real(kind=dp), dimension(:), allocatable :: density_array, kappa_array, mw_array
+    real(kind=dp), dimension(:), allocatable :: unique_density_array, unique_kappa_array, unique_mw_array
+    ! Notes:
+    !   ntot_aspectype = overall number of aerosol chemical species defined (over all modes)
+    !   specdens_amode(l) = dry density (kg/m^3) of aerosol chemical species type l
+    !   specmw_amode(l) = molecular weight (kg/kmol) of aerosol chemical species type l
+    !   specname_amode(l) = name of aerosol chemical species type l
+    !   spechygro(l) = hygroscopicity of aerosol chemical species type l
+    !   lspectype_amode(l,m) = index of species type l in mode m
     if (masterproc) then
-      do m = 1,5 ! nmodes
+      ! Number of aerosol chemical species defined (over all modes)
+      print*, 'number of total aerosol species', ntot_aspectype
+      call rad_cnst_get_info(0, nmodes=n_modes)
+      do m = 1,n_modes
          ! Properties of modal species
          call rad_cnst_get_info(0, m, nspec=n_spec)
-         do l = 1, n_spec
+         do l = 1,n_spec
             call rad_cnst_get_aer_props(0, m, l, &
                aername = aername, &
                density_aer = density, &
@@ -781,7 +808,72 @@ end subroutine compute_partmc_emission_inputs
            write(102,*) m,l, trim(aername),density, hygro, lspectype_amode(l,m)
          end do
       end do
+      do l=1,ntot_aspectype
+         write(102,*) trim(specname_amode(l)), specdens_amode(l), specmw_amode(l), spechygro(l)
+      end do 
+
     end if
+
+    ! Unique strings of the aername in the modes
+    call rad_cnst_get_info(0, nmodes=n_modes)
+    total_mam_vars = 0
+    do m =1,n_modes
+       call rad_cnst_get_info(0, m, nspec=n_spec)
+       total_mam_vars = total_mam_vars + n_spec
+    end do
+    allocate(input_array(total_mam_vars))
+    allocate(unique_array(total_mam_vars))
+    allocate(density_array(total_mam_vars))
+    allocate(kappa_array(total_mam_vars))
+    allocate(mw_array(total_mam_vars))
+    allocate(unique_density_array(total_mam_vars))
+    allocate(unique_kappa_array(total_mam_vars))
+    allocate(unique_mw_array(total_mam_vars))
+
+    i_name = 0 
+    do m = 1,n_modes
+       call rad_cnst_get_info(0, m, nspec=n_spec)
+       do l = 1,n_spec
+          call rad_cnst_get_aer_props(0, m, l, &
+               aername = aername, &
+               density_aer = density, &
+               hygro_aer = hygro)
+          i_name = i_name + 1
+          input_array(i_name) = aername
+          density_array(i_name) = density 
+          kappa_array(i_name) =  hygro
+          mw_array(i_name) = specmw_amode(l)
+      end do
+    end do
+
+   unique_count = 0
+   do i = 1,total_mam_vars
+    is_unique = .true.
+    do j = 1, unique_count
+      if (trim(input_array(i)) == trim(unique_array(j))) then
+        is_unique = .false.
+        exit
+      end if
+    end do
+    if (is_unique) then
+      unique_count = unique_count + 1
+      unique_array(unique_count) = input_array(i)
+      unique_density_array(unique_count) = density_array(i)
+      unique_kappa_array(unique_count) = kappa_array(i)
+      unique_mw_array(unique_count) = mw_array(i)     
+    end if
+  end do
+
+!    if(masterproc) then
+!       do i=1,unique_count
+!          write(102,*) unique_array(i)
+!       end do
+!    end if
+
+    ! Option 1
+    n_aero_spec = unique_count
+    ! Option 2
+    !n_aero_spec = ntot_aspectype
 
     n_swbands = 1
     call ensure_string_array_size(aero_data%name, n_aero_spec)
@@ -792,12 +884,19 @@ end subroutine compute_partmc_emission_inputs
     call ensure_real_array_size(aero_data%molec_weight, n_aero_spec)
     call ensure_real_array_size(aero_data%kappa, n_aero_spec)
 
-    ! Set aerosol properties
     do i_spec = 1,n_aero_spec
-       aero_data%name(i_spec) = mosaic_spec_name(i_spec)
-       aero_data%density(i_spec) = 1800.0d0
-       aero_data%kappa(i_spec) = 0.1d0
-       aero_data%molec_weight(i_spec) = 18.0d0
+       ! Option 1 with minor issue of molecular weight
+       aero_data%name(i_spec) = trim(unique_array(i_spec))
+       aero_data%density(i_spec) = unique_density_array(i_spec)
+       aero_data%kappa(i_spec) = unique_kappa_array(i_spec)
+       aero_data%molec_weight(i_spec) = unique_mw_array(i_spec) 
+
+       ! Option 2
+!       aero_data%name(i_spec) = specname_amode(i_spec)
+!       aero_data%density(i_spec) = specdens_amode(i_spec)
+!       aero_data%kappa(i_spec) = spechygro(i_spec)
+!       aero_data%molec_weight(i_spec) = specmw_amode(i_spec)
+
        aero_data%num_ions(i_spec) = 0
     end do
 
@@ -811,7 +910,22 @@ end subroutine compute_partmc_emission_inputs
 
     call fractal_set_spherical(aero_data%fractal)
 
-
+    ! Map MAM "species" to PartMC species
+    allocate(mam_spec_to_partmc_spec(n_modes, nspec_max_modes))
+    mam_spec_to_partmc_spec = 0
+    do m = 1,n_modes
+       call rad_cnst_get_info(0, m, nspec=n_spec)
+       do l = 1,n_spec
+          call rad_cnst_get_aer_props(0, m, l, &
+               aername = aername)
+          ! Find the index
+          mam_spec_to_partmc_spec(m,l) = aero_data_spec_by_name(aero_data, aername) 
+      end do
+      if (masterproc) then
+         write(102,*) mam_spec_to_partmc_spec(m,:n_spec)
+      end if
+    end do
+    
     ! Print results
     if (masterproc) then
        write(102,*) 'Contents of aero_data'

--- a/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
+++ b/components/eam/src/chemistry/partmc_interface/partmc_mod.F90
@@ -266,7 +266,7 @@ end subroutine compute_partmc_emission_inputs
     character(len=AERO_MODE_NAME_LEN) :: mode_name
     character(len=SPEC_LINE_MAX_VAR_LEN) :: weight_class_name
 
-    n_part_ideal = 50
+    n_part_ideal = 50.0d0
 
     env_state_init%elapsed_time = 0d0
     
@@ -651,10 +651,14 @@ end subroutine compute_partmc_emission_inputs
     integer :: lchnk, ncol
     type(aero_dist_t) :: aero_dist_init
     character(len=SPEC_LINE_MAX_VAR_LEN) :: weight_class_name
-    integer :: i_mode, i_spec, kk, icol
+    integer :: i_mode, i_spec, kk, icol, ll
     integer :: num_idx, idx_chm, spec_idx, nspec
-    real(kind=dp) :: dryvol, dumfac, dummwdens, dgncur_a, num_a
-    real(kind=dp), parameter :: third = 1.0 / 3.0
+    real(kind=dp) :: dryvol, dumfac, dummwdens, dgnum_dry, num_a
+    real(kind=dp), parameter :: third = 1.0d0 / 3.0d0
+    integer :: list_idx
+
+    ! Initialize variables
+    list_idx = 0  ! Climate list by default
 
     lchnk = state%lchnk
     ncol  = state%ncol
@@ -679,34 +683,54 @@ end subroutine compute_partmc_emission_inputs
        do icol = 1,ncol
           do i_mode = 1,ntot_amode
              ! Set number concentration of the mode
-             num_idx = numptr_amode(i_mode)
-             idx_chm = map2chm(num_idx)
              call rad_cnst_get_mode_num_idx(i_mode, num_idx)
-             aero_dist_init%mode(i_mode)%num_conc = state%q(icol,kk,num_idx)
+             idx_chm = map2chm(num_idx)
+             aero_dist_init%mode(i_mode)%num_conc = state%q(icol,kk,idx_chm)
              aero_dist_init%mode(i_mode)%vol_frac = 0.0d0
              ! Set volume fraction of the mode
-             call rad_cnst_get_info(0, i_mode, nspec=nspec)
+             call rad_cnst_get_info(list_idx, i_mode, nspec=nspec)
              dryvol = 0.d0
              do i_spec = 1,nspec
                 call rad_cnst_get_mam_mmr_idx(i_mode, i_spec, spec_idx)
                 idx_chm = map2chm(spec_idx)
+                ll = mam_spec_to_partmc_spec(i_mode, i_spec)
                 ! Convert from mass mixing ratio to volume fraction using density
-                aero_dist_init%mode(i_mode)%vol_frac(spec_idx) = &
-                     state%q(icol,kk,idx_chm) / aero_data%density(spec_idx)
+                aero_dist_init%mode(i_mode)%vol_frac(ll) = &
+                     state%q(icol,kk,idx_chm) / aero_data%density(ll)
                 ! Compute dry volume of mode for diameter calculation
-                dummwdens = 1.0d0 / aero_data%density(spec_idx)
+                dummwdens = 1.0d0 / aero_data%density(ll)
                 dryvol = dryvol + max(0.0d0, state%q(icol,kk,idx_chm))*dummwdens
              end do
-
+             ! Normalize volume fractions
+             if (sum(aero_dist_init%mode(i_mode)%vol_frac) > 0.0d0) then
+                aero_dist_init%mode(i_mode)%vol_frac = aero_dist_init%mode(i_mode)%vol_frac / sum(aero_dist_init%mode(i_mode)%vol_frac)
+             else
+                aero_dist_init%mode(i_mode)%vol_frac = 1.0d0 / aero_data_n_spec(aero_data)
+             end if
              ! Calculate geometric median diameter
-             dumfac = exp(4.5d0*log(sigmag_amode(i_mode))**2)*const%pi/6.0d0
-             dgncur_a = (dryvol/(dumfac*num_a))**third
-             aero_dist_init%mode(i_mode)%char_radius = dgncur_a / 2.0d0
-             !if (masterproc)
-                !write(102,*) i_mode, num_idx, idx_chm, phys_state(ichunk)%q(icol,kk,idx_chm), &
-                     !phys_state(ichunk)%q(icol,kk,num_idx)
-             !endif
+             dumfac = exp(4.5d0 * log(sigmag_amode(i_mode))**2) * const%pi / 6.0d0
+             if (aero_dist_init%mode(i_mode)%num_conc  > 0.0d0) then
+                dgnum_dry = (dryvol / (dumfac * aero_dist_init%mode(i_mode)%num_conc))**third
+             else
+                dgnum_dry = 0.0d0
+             end if
+             aero_dist_init%mode(i_mode)%char_radius = dgnum_dry / 2.0d0
           end do
+          if (masterproc) then
+             if (icol == 1 .and. kk == pver) then
+               do i_mode = 1,ntot_amode
+                write(102,*) '-----------------------------------------'
+                write(102,*) 'Initial condition for mode ', i_mode
+                write(102,*) 'radius:', aero_dist_init%mode(i_mode)%char_radius
+                write(102,*) 'number concentration:', aero_dist_init%mode(i_mode)%num_conc
+                do i_spec = 1,aero_data_n_spec(aero_data)
+                   write(102,*) 'volume fraction for ', trim(aero_data%name(i_spec)), ':', &
+                        aero_dist_init%mode(i_mode)%vol_frac(i_spec)
+                end do
+               end do
+             end if
+
+          end if
           call aero_state_add_aero_dist_sample(aero_state_array(lchnk)%aero_state(icol,kk), &
                aero_data, aero_dist_init, 1d0, 1d0, 0d0, run_part_opt%allow_doubling, &
                run_part_opt%allow_halving)


### PR DESCRIPTION
This PR adds the following:
- Per-gridcell aerosol state: an aero_state is now allocated and time-stepped for every (column, level), initialized from the first-timestep MAM constituent fields.
- Sector-resolved anthropogenic emissions: mapping each present (MAM-group, CMIP6 sector) pair (AGR, ENE, IND, RCO, SHP, SLV, TRA, WST) to a PartMC log-normal emission mode, sourced from the sector-resolved surface-emission inventory.
- Natural-source emissions: sea salt and dust are emitted as bin-resolved sampled modes: sea salt from the sslt_sections flux polynomials, dust from the MAM dust_emis mass flux subdivided into log-spaced sub-bins per MAM bin.
- A legacy `cflx`-based emission pathway is retained behind the `use_sector_emissions` toggle. This will emit based on the MAM modes with their collapsed mixing state.

Summary of actual changes to files:
- `partmc_interface/partmc_mod.F90`: per-gridcell state, emission sector building, sector and natural-source emission inputs mapped to PartMC modes, and initial conditions mapped to modes.
- `chemistry/mozart/mo_srf_emissions.F90`: accessors for sector names and per-sector surface fluxes
- `modal_aero/dust_model.F90`, `modal_aero/aero_model.F90`: expose dust and sea salt information for creating natural emissions.